### PR TITLE
feat: add server URL to served OpenAPI specs.

### DIFF
--- a/external/plugins/swaggerui/plugin.go
+++ b/external/plugins/swaggerui/plugin.go
@@ -15,13 +15,13 @@ type SwaggerUI struct {
 	logger hclog.Logger
 }
 
-func main() {
-	logger := hclog.New(&hclog.LoggerOptions{
-		Level:      hclog.Trace,
-		Output:     os.Stderr,
-		JSONFormat: true,
-	})
+var logger = hclog.New(&hclog.LoggerOptions{
+	Level:      hclog.Trace,
+	Output:     os.Stderr,
+	JSONFormat: true,
+})
 
+func main() {
 	impl := &SwaggerUI{
 		logger: logger,
 	}

--- a/external/plugins/swaggerui/spec.go
+++ b/external/plugins/swaggerui/spec.go
@@ -1,7 +1,12 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
 	"github.com/imposter-project/imposter-go/external/shared"
+	"gopkg.in/yaml.v3"
+	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -30,20 +35,112 @@ func generateSpecConfig(configs []shared.LightweightConfig) error {
 	return nil
 }
 
-// serveRawSpec serves the raw OpenAPI spec file based on the provided path.
+// getServerURL constructs the server URL from environment variables
+func getServerURL() string {
+	serverURL := os.Getenv("IMPOSTER_SERVER_URL")
+	if serverURL != "" {
+		return serverURL
+	}
+
+	port := os.Getenv("IMPOSTER_PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	var hostSuffix string
+	if port != "80" {
+		hostSuffix = fmt.Sprintf(":%s", port)
+	}
+	return fmt.Sprintf("http://localhost%s", hostSuffix)
+}
+
+// serveRawSpec serves the OpenAPI spec file with server URL modifications.
 // If no matching spec is found, it returns nil.
 func serveRawSpec(path string) *shared.HandlerResponse {
-	var response *shared.HandlerResponse
 	for _, specConfig := range specConfigs {
 		if path == specConfig.URL {
-			// TODO instead of serving the raw spec, parse it and add the server URL as the first server entry, then marshal it back to JSON.
-			response = &shared.HandlerResponse{
-				FileBaseDir: specConfig.ConfigDir,
-				StatusCode:  200,
-				File:        specConfig.OriginalPath,
+			// Read and parse the spec file
+			specPath := filepath.Join(specConfig.ConfigDir, specConfig.OriginalPath)
+			specData, err := os.ReadFile(specPath)
+			if err != nil {
+				return &shared.HandlerResponse{
+					StatusCode: 500,
+					Body:       []byte(fmt.Sprintf("Error reading spec file: %v", err)),
+				}
 			}
-			break
+
+			// Parse the spec into a map
+			var specMap map[string]interface{}
+
+			// YAML parser will handle both YAML and JSON formats
+			if err := yaml.Unmarshal(specData, &specMap); err != nil {
+				return &shared.HandlerResponse{
+					StatusCode: 500,
+					Body:       []byte(fmt.Sprintf("Error parsing spec file: %v", err)),
+				}
+			}
+
+			// Add server URL to the spec
+			serverURL := getServerURL()
+
+			// Check if this is OpenAPI 3.x or Swagger 2.0
+			if openapi, exists := specMap["openapi"]; exists {
+				// OpenAPI 3.x - add to servers array
+				if openapiVersion, ok := openapi.(string); ok && strings.HasPrefix(openapiVersion, "3.") {
+					servers, exists := specMap["servers"]
+					if !exists {
+						servers = []interface{}{}
+					}
+
+					serverList, ok := servers.([]interface{})
+					if !ok {
+						serverList = []interface{}{}
+					}
+
+					// Add server URL as first entry
+					newServer := map[string]interface{}{"url": serverURL}
+					serverList = append([]interface{}{newServer}, serverList...)
+					specMap["servers"] = serverList
+				}
+			} else if _, exists := specMap["swagger"]; exists {
+				// Swagger 2.0 - set basePath and host
+				if swaggerVersion, ok := specMap["swagger"].(string); ok && strings.HasPrefix(swaggerVersion, "2.") {
+					// Parse the server URL to extract host and basePath
+					if strings.HasPrefix(serverURL, "http://") {
+						serverURL = strings.TrimPrefix(serverURL, "http://")
+					} else if strings.HasPrefix(serverURL, "https://") {
+						serverURL = strings.TrimPrefix(serverURL, "https://")
+						specMap["schemes"] = []interface{}{"https"}
+					}
+
+					parts := strings.SplitN(serverURL, "/", 2)
+					specMap["host"] = parts[0]
+
+					if len(parts) > 1 {
+						specMap["basePath"] = "/" + parts[1]
+					} else {
+						specMap["basePath"] = "/"
+					}
+				}
+			}
+
+			// Marshal back to JSON
+			jsonData, err := json.MarshalIndent(specMap, "", "  ")
+			if err != nil {
+				return &shared.HandlerResponse{
+					StatusCode: 500,
+					Body:       []byte(fmt.Sprintf("Error marshalling spec: %v", err)),
+				}
+			}
+
+			return &shared.HandlerResponse{
+				StatusCode: 200,
+				Body:       jsonData,
+				Headers: map[string]string{
+					"Content-Type": "application/json",
+				},
+			}
 		}
 	}
-	return response
+	return nil
 }

--- a/external/plugins/swaggerui/spec.go
+++ b/external/plugins/swaggerui/spec.go
@@ -8,9 +8,13 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 )
 
 var specConfigs []SpecConfig
+
+var mu sync.RWMutex
+var processedSpecs = make(map[string][]byte)
 
 type SpecConfig struct {
 	Name         string `json:"name"`
@@ -59,88 +63,107 @@ func getServerURL() string {
 func serveRawSpec(path string) *shared.HandlerResponse {
 	for _, specConfig := range specConfigs {
 		if path == specConfig.URL {
-			// Read and parse the spec file
-			specPath := filepath.Join(specConfig.ConfigDir, specConfig.OriginalPath)
-			specData, err := os.ReadFile(specPath)
-			if err != nil {
-				return &shared.HandlerResponse{
-					StatusCode: 500,
-					Body:       []byte(fmt.Sprintf("Error reading spec file: %v", err)),
-				}
-			}
-
-			// Parse the spec into a map
-			var specMap map[string]interface{}
-
-			// YAML parser will handle both YAML and JSON formats
-			if err := yaml.Unmarshal(specData, &specMap); err != nil {
-				return &shared.HandlerResponse{
-					StatusCode: 500,
-					Body:       []byte(fmt.Sprintf("Error parsing spec file: %v", err)),
-				}
-			}
-
-			// Add server URL to the spec
-			serverURL := getServerURL()
-
-			// Check if this is OpenAPI 3.x or Swagger 2.0
-			if openapi, exists := specMap["openapi"]; exists {
-				// OpenAPI 3.x - add to servers array
-				if openapiVersion, ok := openapi.(string); ok && strings.HasPrefix(openapiVersion, "3.") {
-					servers, exists := specMap["servers"]
-					if !exists {
-						servers = []interface{}{}
-					}
-
-					serverList, ok := servers.([]interface{})
-					if !ok {
-						serverList = []interface{}{}
-					}
-
-					// Add server URL as first entry
-					newServer := map[string]interface{}{"url": serverURL}
-					serverList = append([]interface{}{newServer}, serverList...)
-					specMap["servers"] = serverList
-				}
-			} else if _, exists := specMap["swagger"]; exists {
-				// Swagger 2.0 - set basePath and host
-				if swaggerVersion, ok := specMap["swagger"].(string); ok && strings.HasPrefix(swaggerVersion, "2.") {
-					// Parse the server URL to extract host and basePath
-					if strings.HasPrefix(serverURL, "http://") {
-						serverURL = strings.TrimPrefix(serverURL, "http://")
-					} else if strings.HasPrefix(serverURL, "https://") {
-						serverURL = strings.TrimPrefix(serverURL, "https://")
-						specMap["schemes"] = []interface{}{"https"}
-					}
-
-					parts := strings.SplitN(serverURL, "/", 2)
-					specMap["host"] = parts[0]
-
-					if len(parts) > 1 {
-						specMap["basePath"] = "/" + parts[1]
-					} else {
-						specMap["basePath"] = "/"
-					}
-				}
-			}
-
-			// Marshal back to JSON
-			jsonData, err := json.MarshalIndent(specMap, "", "  ")
-			if err != nil {
-				return &shared.HandlerResponse{
-					StatusCode: 500,
-					Body:       []byte(fmt.Sprintf("Error marshalling spec: %v", err)),
-				}
-			}
-
-			return &shared.HandlerResponse{
-				StatusCode: 200,
-				Body:       jsonData,
-				Headers: map[string]string{
-					"Content-Type": "application/json",
-				},
-			}
+			return getSpec(specConfig)
 		}
 	}
 	return nil
+}
+
+func getSpec(specConfig SpecConfig) *shared.HandlerResponse {
+	specPath := filepath.Join(specConfig.ConfigDir, specConfig.OriginalPath)
+	jsonData := readSpecFromCache(specPath)
+
+	if jsonData == nil {
+		mu.Lock()
+		defer mu.Unlock()
+
+		logger.Trace("loading spec file", "path", specPath)
+		specData, err := os.ReadFile(specPath)
+		if err != nil {
+			return &shared.HandlerResponse{
+				StatusCode: 500,
+				Body:       []byte(fmt.Sprintf("Error reading spec file: %v", err)),
+			}
+		}
+
+		// YAML parser will handle both YAML and JSON formats
+		var specMap map[string]interface{}
+		if err := yaml.Unmarshal(specData, &specMap); err != nil {
+			return &shared.HandlerResponse{
+				StatusCode: 500,
+				Body:       []byte(fmt.Sprintf("Error parsing spec file: %v", err)),
+			}
+		}
+
+		serverURL := getServerURL()
+		appendServerUrl(specMap, serverURL)
+
+		jsonData, err = json.MarshalIndent(specMap, "", "  ")
+		if err != nil {
+			return &shared.HandlerResponse{
+				StatusCode: 500,
+				Body:       []byte(fmt.Sprintf("Error marshalling spec: %v", err)),
+			}
+		}
+
+		processedSpecs[specPath] = jsonData
+	}
+
+	return &shared.HandlerResponse{
+		StatusCode: 200,
+		Body:       jsonData,
+		Headers: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+}
+
+func readSpecFromCache(specPath string) []byte {
+	mu.RLock()
+	defer mu.RUnlock()
+	return processedSpecs[specPath]
+}
+
+// appendServerUrl modifies the OpenAPI spec map to include the server URL.
+func appendServerUrl(specMap map[string]interface{}, serverURL string) {
+	// Check if this is OpenAPI 3.x or Swagger 2.0
+	if openapi, exists := specMap["openapi"]; exists {
+		// OpenAPI 3.x - add to servers array
+		if openapiVersion, ok := openapi.(string); ok && strings.HasPrefix(openapiVersion, "3.") {
+			servers, exists := specMap["servers"]
+			if !exists {
+				servers = []interface{}{}
+			}
+
+			serverList, ok := servers.([]interface{})
+			if !ok {
+				serverList = []interface{}{}
+			}
+
+			// Add server URL as first entry
+			newServer := map[string]interface{}{"url": serverURL}
+			serverList = append([]interface{}{newServer}, serverList...)
+			specMap["servers"] = serverList
+		}
+	} else if _, exists := specMap["swagger"]; exists {
+		// Swagger 2.0 - set basePath and host
+		if swaggerVersion, ok := specMap["swagger"].(string); ok && strings.HasPrefix(swaggerVersion, "2.") {
+			// Parse the server URL to extract host and basePath
+			if strings.HasPrefix(serverURL, "http://") {
+				serverURL = strings.TrimPrefix(serverURL, "http://")
+			} else if strings.HasPrefix(serverURL, "https://") {
+				serverURL = strings.TrimPrefix(serverURL, "https://")
+				specMap["schemes"] = []interface{}{"https"}
+			}
+
+			parts := strings.SplitN(serverURL, "/", 2)
+			specMap["host"] = parts[0]
+
+			if len(parts) > 1 {
+				specMap["basePath"] = "/" + parts[1]
+			} else {
+				specMap["basePath"] = "/"
+			}
+		}
+	}
 }

--- a/external/plugins/swaggerui/spec_test.go
+++ b/external/plugins/swaggerui/spec_test.go
@@ -1,0 +1,328 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetServerURL(t *testing.T) {
+	// Test with IMPOSTER_SERVER_URL set
+	os.Setenv("IMPOSTER_SERVER_URL", "https://example.com:8080")
+	defer os.Unsetenv("IMPOSTER_SERVER_URL")
+
+	result := getServerURL()
+	expected := "https://example.com:8080"
+	if result != expected {
+		t.Errorf("Expected %s, got %s", expected, result)
+	}
+
+	// Test with custom port
+	os.Unsetenv("IMPOSTER_SERVER_URL")
+	os.Setenv("IMPOSTER_PORT", "3000")
+	defer os.Unsetenv("IMPOSTER_PORT")
+
+	result = getServerURL()
+	expected = "http://localhost:3000"
+	if result != expected {
+		t.Errorf("Expected %s, got %s", expected, result)
+	}
+
+	// Test with default port 80
+	os.Setenv("IMPOSTER_PORT", "80")
+	result = getServerURL()
+	expected = "http://localhost"
+	if result != expected {
+		t.Errorf("Expected %s, got %s", expected, result)
+	}
+}
+
+func TestServeRawSpec_OpenAPI3(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+
+	// Create test OpenAPI 3.0 spec
+	openapi3Spec := `{
+		"openapi": "3.0.0",
+		"info": {
+			"title": "Test API",
+			"version": "1.0.0"
+		},
+		"paths": {
+			"/test": {
+				"get": {
+					"responses": {
+						"200": {
+							"description": "OK"
+						}
+					}
+				}
+			}
+		}
+	}`
+
+	specFile := filepath.Join(tmpDir, "openapi.json")
+	err := os.WriteFile(specFile, []byte(openapi3Spec), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write test spec file: %v", err)
+	}
+
+	// Set up test environment
+	os.Setenv("IMPOSTER_SERVER_URL", "https://test.example.com")
+	defer os.Unsetenv("IMPOSTER_SERVER_URL")
+
+	// Set up specConfigs
+	specConfigs = []SpecConfig{
+		{
+			Name:         "openapi.json",
+			URL:          "/_spec/openapi/openapi.json",
+			OriginalPath: "openapi.json",
+			ConfigDir:    tmpDir,
+		},
+	}
+
+	// Test the function
+	result := serveRawSpec("/_spec/openapi/openapi.json")
+
+	if result == nil {
+		t.Fatal("Expected non-nil result")
+	}
+
+	if result.StatusCode != 200 {
+		t.Errorf("Expected status code 200, got %d", result.StatusCode)
+	}
+
+	if result.Headers["Content-Type"] != "application/json" {
+		t.Errorf("Expected Content-Type application/json, got %s", result.Headers["Content-Type"])
+	}
+
+	// Parse the response body
+	var responseSpec map[string]interface{}
+	err = json.Unmarshal(result.Body, &responseSpec)
+	if err != nil {
+		t.Fatalf("Failed to parse response JSON: %v", err)
+	}
+
+	// Verify that servers array was added
+	servers, exists := responseSpec["servers"]
+	if !exists {
+		t.Error("Expected servers array to exist")
+	}
+
+	serverList, ok := servers.([]interface{})
+	if !ok {
+		t.Error("Expected servers to be an array")
+	}
+
+	if len(serverList) == 0 {
+		t.Error("Expected at least one server entry")
+	}
+
+	firstServer, ok := serverList[0].(map[string]interface{})
+	if !ok {
+		t.Error("Expected first server to be an object")
+	}
+
+	serverURL, exists := firstServer["url"]
+	if !exists {
+		t.Error("Expected server URL to exist")
+	}
+
+	if serverURL != "https://test.example.com" {
+		t.Errorf("Expected server URL to be 'https://test.example.com', got %s", serverURL)
+	}
+}
+
+func TestServeRawSpec_Swagger2(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+
+	// Create test Swagger 2.0 spec
+	swagger2Spec := `{
+		"swagger": "2.0",
+		"info": {
+			"title": "Test API",
+			"version": "1.0.0"
+		},
+		"paths": {
+			"/test": {
+				"get": {
+					"responses": {
+						"200": {
+							"description": "OK"
+						}
+					}
+				}
+			}
+		}
+	}`
+
+	specFile := filepath.Join(tmpDir, "swagger.json")
+	err := os.WriteFile(specFile, []byte(swagger2Spec), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write test spec file: %v", err)
+	}
+
+	// Set up test environment
+	os.Setenv("IMPOSTER_SERVER_URL", "https://test.example.com/api/v1")
+	defer os.Unsetenv("IMPOSTER_SERVER_URL")
+
+	// Set up specConfigs
+	specConfigs = []SpecConfig{
+		{
+			Name:         "swagger.json",
+			URL:          "/_spec/openapi/swagger.json",
+			OriginalPath: "swagger.json",
+			ConfigDir:    tmpDir,
+		},
+	}
+
+	// Test the function
+	result := serveRawSpec("/_spec/openapi/swagger.json")
+
+	if result == nil {
+		t.Fatal("Expected non-nil result")
+	}
+
+	if result.StatusCode != 200 {
+		t.Errorf("Expected status code 200, got %d", result.StatusCode)
+	}
+
+	// Parse the response body
+	var responseSpec map[string]interface{}
+	err = json.Unmarshal(result.Body, &responseSpec)
+	if err != nil {
+		t.Fatalf("Failed to parse response JSON: %v", err)
+	}
+
+	// Verify that host and basePath were set
+	host, exists := responseSpec["host"]
+	if !exists {
+		t.Error("Expected host to exist")
+	}
+
+	if host != "test.example.com" {
+		t.Errorf("Expected host to be 'test.example.com', got %s", host)
+	}
+
+	basePath, exists := responseSpec["basePath"]
+	if !exists {
+		t.Error("Expected basePath to exist")
+	}
+
+	if basePath != "/api/v1" {
+		t.Errorf("Expected basePath to be '/api/v1', got %s", basePath)
+	}
+
+	// Verify that schemes was set to https
+	schemes, exists := responseSpec["schemes"]
+	if !exists {
+		t.Error("Expected schemes to exist")
+	}
+
+	schemeList, ok := schemes.([]interface{})
+	if !ok {
+		t.Error("Expected schemes to be an array")
+	}
+
+	if len(schemeList) == 0 || schemeList[0] != "https" {
+		t.Error("Expected first scheme to be 'https'")
+	}
+}
+
+func TestServeRawSpec_YAML(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+
+	// Create test YAML OpenAPI 3.0 spec
+	yamlSpec := `openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /test:
+    get:
+      responses:
+        '200':
+          description: OK`
+
+	specFile := filepath.Join(tmpDir, "openapi.yaml")
+	err := os.WriteFile(specFile, []byte(yamlSpec), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write test spec file: %v", err)
+	}
+
+	// Set up test environment
+	os.Setenv("IMPOSTER_SERVER_URL", "http://localhost:8080")
+	defer os.Unsetenv("IMPOSTER_SERVER_URL")
+
+	// Set up specConfigs
+	specConfigs = []SpecConfig{
+		{
+			Name:         "openapi.yaml",
+			URL:          "/_spec/openapi/openapi.yaml",
+			OriginalPath: "openapi.yaml",
+			ConfigDir:    tmpDir,
+		},
+	}
+
+	// Test the function
+	result := serveRawSpec("/_spec/openapi/openapi.yaml")
+
+	if result == nil {
+		t.Fatal("Expected non-nil result")
+	}
+
+	if result.StatusCode != 200 {
+		t.Errorf("Expected status code 200, got %d", result.StatusCode)
+	}
+
+	// Parse the response body
+	var responseSpec map[string]interface{}
+	err = json.Unmarshal(result.Body, &responseSpec)
+	if err != nil {
+		t.Fatalf("Failed to parse response JSON: %v", err)
+	}
+
+	// Verify that servers array was added
+	servers, exists := responseSpec["servers"]
+	if !exists {
+		t.Error("Expected servers array to exist")
+	}
+
+	serverList, ok := servers.([]interface{})
+	if !ok {
+		t.Error("Expected servers to be an array")
+	}
+
+	if len(serverList) == 0 {
+		t.Error("Expected at least one server entry")
+	}
+
+	firstServer, ok := serverList[0].(map[string]interface{})
+	if !ok {
+		t.Error("Expected first server to be an object")
+	}
+
+	serverURL, exists := firstServer["url"]
+	if !exists {
+		t.Error("Expected server URL to exist")
+	}
+
+	if serverURL != "http://localhost:8080" {
+		t.Errorf("Expected server URL to be 'http://localhost:8080', got %s", serverURL)
+	}
+}
+
+func TestServeRawSpec_NotFound(t *testing.T) {
+	// Set up empty specConfigs
+	specConfigs = []SpecConfig{}
+
+	// Test with non-existent spec
+	result := serveRawSpec("/_spec/openapi/nonexistent.json")
+
+	if result != nil {
+		t.Error("Expected nil result for non-existent spec")
+	}
+}

--- a/internal/adapter/common.go
+++ b/internal/adapter/common.go
@@ -1,6 +1,7 @@
 package adapter
 
 import (
+	"fmt"
 	"github.com/imposter-project/imposter-go/external"
 	"github.com/imposter-project/imposter-go/internal/version"
 	"github.com/imposter-project/imposter-go/pkg/logger"
@@ -26,7 +27,7 @@ func InitialiseImposter(configDirArg string) (*config.ImposterConfig, []plugin.P
 
 	for _, configDir := range configDirs {
 		if info, err := os.Stat(configDir); os.IsNotExist(err) || !info.IsDir() {
-			panic("Specified path is not a valid directory")
+			panic(fmt.Errorf("specified config dir '%s' is not a valid directory", configDir))
 		}
 
 		cfgs := config.LoadConfig(configDir, imposterConfig)

--- a/internal/response/response.go
+++ b/internal/response/response.go
@@ -190,6 +190,9 @@ func SetContentTypeHeader(
 	defaultFileContentType string,
 	fallbackContentType string,
 ) {
+	if len(rs.Body) == 0 {
+		return
+	}
 	if _, exists := rs.Headers["Content-Type"]; !exists {
 		// If response is from file, try to determine content type from extension
 		if fileNameMIMEHint != "" {


### PR DESCRIPTION
Enhances the Swagger UI plugin by adding server URL to returned OpenAPI specs.

### Enhancements
* Introduced `getServerURL` to construct server URLs dynamically based on environment variables, with fallback defaults (`external/plugins/swaggerui/spec.go`).
* Updated `serveRawSpec` to parse OpenAPI 3.x and Swagger 2.0 specifications, dynamically add server URLs, and handle both JSON and YAML formats. This includes error handling for file reading, parsing, and marshalling (`external/plugins/swaggerui/spec.go`).
