### PR TITLE
Allow external $refs

### DIFF
--- a/internal/config/model.go
+++ b/internal/config/model.go
@@ -403,6 +403,7 @@ type Config struct {
 
 	// OpenAPI-specific fields
 	SpecFile        string            `yaml:"specFile,omitempty"`
+	ExternalBaseURL string            `yaml:"externalBaseUrl,omitempty"`
 	StripServerPath bool              `yaml:"stripServerPath,omitempty"`
 	Validation      *ValidationConfig `yaml:"validation,omitempty"`
 

--- a/plugin/openapi/plugin.go
+++ b/plugin/openapi/plugin.go
@@ -2,6 +2,7 @@ package openapi
 
 import (
 	"fmt"
+
 	"github.com/imposter-project/imposter-go/plugin/rest"
 
 	"github.com/imposter-project/imposter-go/internal/config"
@@ -24,8 +25,10 @@ func NewPluginHandler(cfg *config.Config, imposterConfig *config.ImposterConfig)
 	}
 
 	opts := parserOptions{
-		stripServerPath: cfg.StripServerPath,
+		stripServerPath:          cfg.StripServerPath,
+		externalReferenceBaseURL: cfg.ExternalBaseURL,
 	}
+
 	validate := cfg.Validation != nil && (cfg.Validation.IsRequestValidationEnabled() || cfg.Validation.IsResponseValidationEnabled())
 	parser, err := newOpenAPIParser(specFile, validate, opts)
 	if err != nil {

--- a/plugin/openapi/testdata/externalRef/imposter-config.yaml
+++ b/plugin/openapi/testdata/externalRef/imposter-config.yaml
@@ -1,0 +1,8 @@
+plugin: openapi
+specFile: users-external-ref.yaml
+externalBaseURL: http://example.com
+resources:
+  - path: /users
+    method: GET
+    response:
+      statusCode: 200

--- a/plugin/openapi/testdata/externalRef/users.yaml
+++ b/plugin/openapi/testdata/externalRef/users.yaml
@@ -1,0 +1,44 @@
+openapi: 3.0.2
+info:
+  title: External URL references test
+  description: A test document
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      summary: Get all users
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: 'http://example.com/schemas/user.json'
+  /users/{id}:
+    get:
+      summary: Get a users
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+
+components:
+  schemas:
+    User:
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        username:
+          type: string
+          example: theUser
+        firstName:
+          type: string
+          example: John
+        lastName:
+          type: string
+          example: James

--- a/tools/validate_config/current-format-schema.json
+++ b/tools/validate_config/current-format-schema.json
@@ -13,6 +13,12 @@
                 "basePath": {
                     "type": "string"
                 },
+                "externalBaseURL": {
+                    "type": "string"
+                },
+                "specFile": {
+                    "type": "string"
+                },
                 "wsdlFile": {
                     "type": "string"
                 },
@@ -72,6 +78,14 @@
                     },
                     "additionalProperties": false
                 }
+            },
+            "if": {
+                "plugin": {
+                    "type": { "const": "openapi" }
+                }
+            },
+            "then": {
+                "required": ["specFile"]
             },
             "additionalProperties": false
         }


### PR DESCRIPTION
Hey @outofcoffee - thanks for the config pointers, that fixed the issue I was seeing. However, I ran into another problem as some of our mocks rely on [external references](https://github.com/ministryofjustice/opg-data-lpa-store/blob/main/docs/openapi/openapi.yaml#L304) for component schemas, which, after some digging, I could see wasn't supported.

I've made as minimal a change as possible, not being too familiar with this codebase, so let me know of any changes you want. I also wasn't too sure at what level to test this at, the parser level seemed appropriate but again happy to make changes if you want this further up the stack.