### PR TITLE
build(deps): update Go dependencies and Docker base images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.23'
+        go-version: '1.25'
 
     - name: Build
       run: |
@@ -51,7 +51,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.23'
+        go-version: '1.25'
 
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v7
@@ -75,7 +75,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.23'
+        go-version: '1.25'
 
     - name: Run GoReleaser Snapshot
       uses: goreleaser/goreleaser-action@v7
@@ -122,7 +122,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.23'
+        go-version: '1.25'
 
     - name: Extract version
       id: version

--- a/plugin/openapi/example_gen_test.go
+++ b/plugin/openapi/example_gen_test.go
@@ -11,7 +11,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestGenerateExampleJSON(t *testing.T) {

--- a/plugin/openapi/oas2_parser.go
+++ b/plugin/openapi/oas2_parser.go
@@ -20,14 +20,9 @@ type openAPI2Parser struct {
 // newOpenAPI2Parser creates a new OpenAPIParser for OpenAPI 2 documents
 func newOpenAPI2Parser(document libopenapi.Document, validator *validator.Validator, opts parserOptions) (*openAPI2Parser, error) {
 	logger.Debugf("creating OpenAPI 2 parser")
-	v2Model, errors := document.BuildV2Model()
-
-	if len(errors) > 0 {
-		var errorMessages string
-		for i := range errors {
-			errorMessages += fmt.Sprintf("error: %e\n", errors[i])
-		}
-		return nil, fmt.Errorf("cannot create v2 model from document: %d errors reported: %v", len(errors), errorMessages)
+	v2Model, err := document.BuildV2Model()
+	if err != nil {
+		return nil, fmt.Errorf("cannot create v2 model from document: %w", err)
 	}
 
 	parser := &openAPI2Parser{

--- a/plugin/openapi/oas3_parser.go
+++ b/plugin/openapi/oas3_parser.go
@@ -22,14 +22,9 @@ type openAPI3Parser struct {
 // newOpenAPI3Parser creates a new OpenAPIParser for OpenAPI 3 documents
 func newOpenAPI3Parser(document libopenapi.Document, validator *validator.Validator, opts parserOptions) (*openAPI3Parser, error) {
 	logger.Debugf("creating OpenAPI 3 parser")
-	v3Model, errors := document.BuildV3Model()
-
-	if len(errors) > 0 {
-		var errorMessages string
-		for i := range errors {
-			errorMessages += fmt.Sprintf("error: %e\n", errors[i])
-		}
-		return nil, fmt.Errorf("cannot create v3 model from document: %d errors reported: %v", len(errors), errorMessages)
+	v3Model, err := document.BuildV3Model()
+	if err != nil {
+		return nil, fmt.Errorf("cannot create v3 model from document: %w", err)
 	}
 
 	var version OpenAPIVersion

--- a/plugin/openapi/util.go
+++ b/plugin/openapi/util.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/imposter-project/imposter-go/pkg/logger"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // yamlNodeToJson converts a YAML node to a string

--- a/plugin/openapi/util_test.go
+++ b/plugin/openapi/util_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestYamlNodeToString(t *testing.T) {


### PR DESCRIPTION
Apply open Dependabot PRs: bump Go module dependencies and Docker base images.

## Summary

- Bump 11 Go module dependencies including libopenapi (0.22.3 → 0.35.1), aws-lambda-go (1.49.0 → 1.54.0), aws-sdk-go (1.55.7 → 1.55.8), golang-jwt (5.3.0 → 5.3.1), go-plugin (1.6.3 → 1.7.0), and others
- Update Docker base image from `golang:1.23` to `golang:1.26` in both `distro/core` and `distro/all`
- Adapt openapi plugin to libopenapi v0.35.1 breaking API changes

## Implementation details

- libopenapi v0.35.1 switched its YAML node type from `gopkg.in/yaml.v3` to `go.yaml.in/yaml/v4`, requiring the openapi plugin's util functions and tests to use the new package
- `BuildV2Model()` and `BuildV3Model()` now return a single `error` instead of `[]error`, so the error handling in both parsers was simplified accordingly