### PR TITLE
fix: populate formParams from multipart/form-data requests

### DIFF
--- a/internal/capture/capture.go
+++ b/internal/capture/capture.go
@@ -40,9 +40,7 @@ func getValueFromCaptureConfig(imposterConfig *config.ImposterConfig, reqMatcher
 	} else if key.QueryParam != "" {
 		return exch.Request.Request.URL.Query().Get(key.QueryParam)
 	} else if key.FormParam != "" {
-		if err := exch.Request.Request.ParseForm(); err == nil {
-			return exch.Request.Request.FormValue(key.FormParam)
-		}
+		return utils.GetFormValue(exch.Request.Request, key.FormParam)
 	} else if key.RequestHeader != "" {
 		return exch.Request.Request.Header.Get(key.RequestHeader)
 	} else if key.Expression != "" {

--- a/internal/capture/capture_test.go
+++ b/internal/capture/capture_test.go
@@ -3,6 +3,7 @@ package capture
 import (
 	"bytes"
 	"github.com/imposter-project/imposter-go/internal/exchange"
+	"mime/multipart"
 	"net/http"
 	"strings"
 	"testing"
@@ -129,6 +130,40 @@ func TestCaptureRequestData(t *testing.T) {
 				req, _ := http.NewRequest("POST", "/", body)
 				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 				return req, &config.RequestMatcher{}, []byte("field=form-data")
+			},
+			imposterConfig: &config.ImposterConfig{},
+			validate: func(t *testing.T, requestStore *store.Store) {
+				val, _ := requestStore.GetValue("formValue")
+				assert.Equal(t, "form-data", val)
+			},
+		},
+		{
+			name: "capture multipart form parameter",
+			resource: config.Resource{
+				BaseResource: config.BaseResource{
+					Capture: map[string]config.Capture{
+						"test": {
+							Enabled: boolPtr(true),
+							Key: config.CaptureConfig{
+								Const: "formValue",
+							},
+							CaptureConfig: config.CaptureConfig{
+								FormParam: "field",
+							},
+							Store: "request",
+						},
+					},
+				},
+			},
+			setupRequest: func() (*http.Request, *config.RequestMatcher, []byte) {
+				var buf bytes.Buffer
+				w := multipart.NewWriter(&buf)
+				_ = w.WriteField("field", "form-data")
+				_ = w.Close()
+				body := buf.Bytes()
+				req, _ := http.NewRequest("POST", "/", bytes.NewReader(body))
+				req.Header.Set("Content-Type", w.FormDataContentType())
+				return req, &config.RequestMatcher{}, body
 			},
 			imposterConfig: &config.ImposterConfig{},
 			validate: func(t *testing.T, requestStore *store.Store) {

--- a/internal/steps/script/context.go
+++ b/internal/steps/script/context.go
@@ -38,16 +38,7 @@ func buildContext(exch *exchange.Exchange, reqMatcher *config.RequestMatcher) ma
 	}
 	reqContext["pathParams"] = pathParams
 
-	// Parse and convert form parameters to a simple map
-	formParams := make(map[string]string)
-	if err := exch.Request.Request.ParseForm(); err == nil {
-		for k, v := range exch.Request.Request.PostForm {
-			if len(v) > 0 {
-				formParams[k] = v[0]
-			}
-		}
-	}
-	reqContext["formParams"] = formParams
+	reqContext["formParams"] = utils.GetFormParams(exch.Request.Request)
 
 	// Set up context object
 	context := make(map[string]interface{})

--- a/internal/steps/script/script_test.go
+++ b/internal/steps/script/script_test.go
@@ -1,6 +1,8 @@
 package script
 
 import (
+	"bytes"
+	"mime/multipart"
 	"net/http"
 	"os"
 	"regexp"
@@ -134,6 +136,40 @@ func TestExecuteScriptStep(t *testing.T) {
 			},
 			reqMatcher: &config.RequestMatcher{
 				Path: "/{path-param}",
+			},
+		},
+		{
+			name: "inline script accessing multipart form params",
+			step: config.Step{
+				Type: config.ScriptStepType,
+				Lang: "javascript",
+				Code: `
+					if (context.request.formParams.key1 !== "value1") {
+						throw new Error("Expected key1=value1 form param, got: " + context.request.formParams.key1);
+					}
+					if (context.request.formParams.key2 !== "value2") {
+						throw new Error("Expected key2=value2 form param, got: " + context.request.formParams.key2);
+					}
+				`,
+			},
+			setupExch: func() *exchange.Exchange {
+				var buf bytes.Buffer
+				w := multipart.NewWriter(&buf)
+				_ = w.WriteField("key1", "value1")
+				_ = w.WriteField("key2", "value2")
+				_ = w.Close()
+				body := buf.Bytes()
+				req, _ := http.NewRequest("POST", "/test", bytes.NewReader(body))
+				req.Header.Set("Content-Type", w.FormDataContentType())
+				return &exchange.Exchange{
+					Request: &exchange.RequestContext{
+						Request: req,
+						Body:    body,
+					},
+				}
+			},
+			reqMatcher: &config.RequestMatcher{
+				Path: "/test",
 			},
 		},
 		{

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -147,8 +147,7 @@ func handleRequestReplacement(field string, reqMatcher *config.RequestMatcher, e
 		return params[key]
 	case strings.HasPrefix(field, "formParams."):
 		key := strings.TrimPrefix(field, "formParams.")
-		_ = exch.Request.Request.ParseForm()
-		return exch.Request.Request.FormValue(key)
+		return utils.GetFormValue(exch.Request.Request, key)
 	default:
 		return ""
 	}

--- a/internal/template/template_test.go
+++ b/internal/template/template_test.go
@@ -3,6 +3,7 @@ package template
 import (
 	"bytes"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"strings"
 	"testing"
@@ -76,6 +77,22 @@ func TestProcessTemplate(t *testing.T) {
 				req, _ := http.NewRequest("POST", "/", nil)
 				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 				return req, body, &config.RequestMatcher{}
+			},
+			imposterConfig: &config.ImposterConfig{ServerPort: "8080"},
+			requestStore:   store.NewRequestStore(),
+			want:           "Form value: value",
+		},
+		{
+			name:     "multipart form parameters",
+			template: "Form value: ${context.request.formParams.key}",
+			setupRequest: func() (*http.Request, string, *config.RequestMatcher) {
+				var buf bytes.Buffer
+				w := multipart.NewWriter(&buf)
+				_ = w.WriteField("key", "value")
+				_ = w.Close()
+				req, _ := http.NewRequest("POST", "/", nil)
+				req.Header.Set("Content-Type", w.FormDataContentType())
+				return req, buf.String(), &config.RequestMatcher{}
 			},
 			imposterConfig: &config.ImposterConfig{ServerPort: "8080"},
 			requestStore:   store.NewRequestStore(),

--- a/pkg/utils/http.go
+++ b/pkg/utils/http.go
@@ -1,6 +1,13 @@
 package utils
 
-import "strings"
+import (
+	"net/http"
+	"strings"
+)
+
+// defaultMaxMultipartMemory mirrors net/http's defaultMaxMemory used by
+// ParseMultipartForm when called via FormValue (32 MiB).
+const defaultMaxMultipartMemory = 32 << 20
 
 // ExtractPathParams extracts path parameters from the request path
 func ExtractPathParams(requestPath, resourcePath string) map[string]string {
@@ -16,4 +23,53 @@ func ExtractPathParams(requestPath, resourcePath string) map[string]string {
 	}
 
 	return pathParams
+}
+
+// parseRequestForms ensures both URL-encoded and multipart form bodies are
+// parsed. Go's ParseForm only handles application/x-www-form-urlencoded; once
+// it has run, r.Form is non-nil and FormValue will no longer trigger
+// ParseMultipartForm on its own, so we must call it explicitly for multipart
+// requests.
+func parseRequestForms(r *http.Request) {
+	_ = r.ParseForm()
+	if isMultipartFormRequest(r) {
+		_ = r.ParseMultipartForm(defaultMaxMultipartMemory)
+	}
+}
+
+func isMultipartFormRequest(r *http.Request) bool {
+	return strings.HasPrefix(r.Header.Get("Content-Type"), "multipart/form-data")
+}
+
+// GetFormParams returns a flat map of form parameters from the request,
+// handling both application/x-www-form-urlencoded and multipart/form-data
+// bodies. Only text fields are included; file parts are ignored. For
+// multi-valued parameters, only the first value is returned.
+func GetFormParams(r *http.Request) map[string]string {
+	formParams := make(map[string]string)
+	parseRequestForms(r)
+
+	for k, v := range r.PostForm {
+		if len(v) > 0 {
+			formParams[k] = v[0]
+		}
+	}
+	if r.MultipartForm != nil {
+		for k, v := range r.MultipartForm.Value {
+			if _, ok := formParams[k]; ok {
+				continue
+			}
+			if len(v) > 0 {
+				formParams[k] = v[0]
+			}
+		}
+	}
+	return formParams
+}
+
+// GetFormValue returns the value of a single form parameter, handling both
+// application/x-www-form-urlencoded and multipart/form-data bodies.
+func GetFormValue(r *http.Request, key string) string {
+	parseRequestForms(r)
+	return r.FormValue(key)
 }

--- a/pkg/utils/http_test.go
+++ b/pkg/utils/http_test.go
@@ -1,7 +1,11 @@
 package utils
 
 import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -77,5 +81,86 @@ func TestExtractPathParams(t *testing.T) {
 				t.Errorf("ExtractPathParams() = %v, want %v", result, tt.expected)
 			}
 		})
+	}
+}
+
+func newMultipartRequest(t *testing.T, fields map[string]string) *http.Request {
+	t.Helper()
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	for k, v := range fields {
+		if err := w.WriteField(k, v); err != nil {
+			t.Fatalf("failed to write field %q: %v", k, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close writer: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, "/", &buf)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	return req
+}
+
+func TestGetFormParams_URLEncoded(t *testing.T) {
+	body := "key1=value1&key2=value2"
+	req, err := http.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	got := GetFormParams(req)
+	want := map[string]string{"key1": "value1", "key2": "value2"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("GetFormParams() = %v, want %v", got, want)
+	}
+}
+
+func TestGetFormParams_Multipart(t *testing.T) {
+	req := newMultipartRequest(t, map[string]string{
+		"name":  "alice",
+		"email": "alice@example.com",
+	})
+
+	got := GetFormParams(req)
+	want := map[string]string{"name": "alice", "email": "alice@example.com"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("GetFormParams() = %v, want %v", got, want)
+	}
+}
+
+func TestGetFormParams_NoBody(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "/", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	got := GetFormParams(req)
+	if len(got) != 0 {
+		t.Errorf("GetFormParams() = %v, want empty map", got)
+	}
+}
+
+func TestGetFormValue_URLEncoded(t *testing.T) {
+	body := "field=form-data"
+	req, err := http.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	if got := GetFormValue(req, "field"); got != "form-data" {
+		t.Errorf("GetFormValue() = %q, want %q", got, "form-data")
+	}
+}
+
+func TestGetFormValue_Multipart(t *testing.T) {
+	req := newMultipartRequest(t, map[string]string{"field": "form-data"})
+
+	if got := GetFormValue(req, "field"); got != "form-data" {
+		t.Errorf("GetFormValue() = %q, want %q", got, "form-data")
 	}
 }


### PR DESCRIPTION
Form parameter extraction now supports `multipart/form-data` bodies in addition to `application/x-www-form-urlencoded`.

Fixes #65

## Summary
- Add `GetFormParams` and `GetFormValue` helpers in `pkg/utils/http.go` that parse both URL-encoded and multipart bodies before reading values.
- Route form parameter access in `internal/capture`, `internal/template`, and the script step context through the new helpers, so `formParams` is populated for multipart requests.
- Add unit and integration tests covering multipart capture, template substitution, script context, and the new utility functions.

## Implementation details
Go's `http.Request.FormValue` only auto-invokes `ParseMultipartForm` when `r.Form` is still nil. As soon as `ParseForm` has run (which the previous code did to handle URL-encoded bodies), `r.Form` is non-nil and multipart parsing is silently skipped. The new `parseRequestForms` helper calls `ParseForm` and then, for multipart requests, explicitly calls `ParseMultipartForm` with the same 32 MiB default that `net/http` uses internally. URL-encoded values take precedence over multipart values when keys collide, and only text fields are exposed (file parts are ignored).