### PR TITLE
feat: add config-level variables support

### DIFF
--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -105,6 +105,39 @@ database:
 | `${env.VAR_NAME}` | Substitute environment variable | `${env.DATABASE_URL}` |
 | `${env.VAR_NAME:-default}` | Substitute with default if not set | `${env.PORT:-8080}` |
 
+## Config-level Variables
+
+For values that are shared across a configuration file but don't need to come
+from the environment, define a top-level `vars` section and reference entries
+using the `${var.NAME}` syntax. Variables are resolved at config parse time and
+work in any string-valued field (paths, response content/file, headers, etc.)
+across all plugins.
+
+```yaml
+plugin: rest
+vars:
+  api_base_path: /api/v2
+  default_host: example.com
+
+resources:
+  - path: ${var.api_base_path}/users
+    response:
+      content: '{"host": "${var.default_host}"}'
+
+  - path: ${var.api_base_path}/items
+    response:
+      content: '{"host": "${var.default_host}"}'
+```
+
+| Syntax | Purpose | Example |
+|--------|---------|---------|
+| `${var.NAME}` | Substitute config-level variable | `${var.api_base_path}` |
+| `${var.NAME:-default}` | Substitute with default if not defined | `${var.region:-us-east-1}` |
+
+Environment variables are substituted before config variables, so a variable
+value may itself contain an `${env.VAR_NAME}` reference. Undefined variable
+references without a default are left intact and a warning is logged at startup.
+
 ## Usage Examples
 
 ### Basic Setup

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -244,6 +244,9 @@ func parseConfig(path string, imposterConfig *ImposterConfig) ([]Config, error) 
 	// Substitute environment variables
 	data = []byte(substituteEnvVars(string(data)))
 
+	// Substitute config-level variables defined in the top-level `vars` section
+	data = []byte(substituteConfigVars(string(data), path))
+
 	var configs []Config
 
 	// Transform legacy config if legacy support is enabled
@@ -294,6 +297,51 @@ func parseMultipleYAMLDocuments(data []byte) ([]Config, error) {
 	}
 
 	return configs, nil
+}
+
+var configVarRefRegex = regexp.MustCompile(`\$\{var\.([A-Za-z0-9_]+)(:-([^}]*))?\}`)
+
+// extractConfigVars reads the top-level `vars` section from every YAML document
+// in the file and merges them into a single key-value map. Later documents take
+// precedence over earlier ones for overlapping keys.
+func extractConfigVars(data []byte) map[string]string {
+	vars := make(map[string]string)
+
+	type varsOnly struct {
+		Vars map[string]string `yaml:"vars"`
+	}
+
+	decoder := yaml.NewDecoder(strings.NewReader(string(data)))
+	for {
+		var doc varsOnly
+		if err := decoder.Decode(&doc); err != nil {
+			break
+		}
+		for k, v := range doc.Vars {
+			vars[k] = v
+		}
+	}
+	return vars
+}
+
+// substituteConfigVars replaces ${var.NAME} and ${var.NAME:-default} references
+// with values from the top-level `vars` section, resolved at config parse time.
+// Undefined references without a default are left intact and a warning is logged.
+func substituteConfigVars(content string, path string) string {
+	vars := extractConfigVars([]byte(content))
+
+	return configVarRefRegex.ReplaceAllStringFunc(content, func(match string) string {
+		groups := configVarRefRegex.FindStringSubmatch(match)
+		name := groups[1]
+		if value, exists := vars[name]; exists {
+			return value
+		}
+		if groups[2] != "" {
+			return groups[3]
+		}
+		logger.Warnf("undefined config variable ${var.%s} referenced in %s", name, path)
+		return match
+	})
 }
 
 // substituteEnvVars replaces ${env.VAR} and ${env.VAR:-default} with environment variable values

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -220,6 +220,61 @@ resources:
 	require.Equal(t, "/api/v1", resource.Response.Headers["X-Test"])
 }
 
+func TestLoadConfig_WithConfigVars(t *testing.T) {
+	tempDir := t.TempDir()
+	imposterConfig := &ImposterConfig{}
+
+	configContent := `plugin: rest
+vars:
+  api_base_path: /api/v2
+  default_host: example.com
+resources:
+  - path: ${var.api_base_path}/users
+    response:
+      content: '{"host": "${var.default_host}", "fallback": "${var.missing:-defaultValue}"}'
+      statusCode: 200
+      headers:
+        X-Host: ${var.default_host}`
+
+	err := os.WriteFile(filepath.Join(tempDir, "test-config.yaml"), []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	configs := LoadConfig(tempDir, imposterConfig)
+	require.Len(t, configs, 1)
+
+	cfg := configs[0]
+	require.Equal(t, "/api/v2", cfg.Vars["api_base_path"])
+	require.Len(t, cfg.Resources, 1)
+
+	resource := cfg.Resources[0]
+	require.Equal(t, "/api/v2/users", resource.Path)
+	require.Equal(t, `{"host": "example.com", "fallback": "defaultValue"}`, resource.Response.Content)
+	require.Equal(t, "example.com", resource.Response.Headers["X-Host"])
+}
+
+func TestLoadConfig_WithUndefinedConfigVar(t *testing.T) {
+	tempDir := t.TempDir()
+	imposterConfig := &ImposterConfig{}
+
+	configContent := `plugin: rest
+vars:
+  known: value
+resources:
+  - path: /test
+    response:
+      content: ${var.known} and ${var.unknown}
+      statusCode: 200`
+
+	err := os.WriteFile(filepath.Join(tempDir, "test-config.yaml"), []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	configs := LoadConfig(tempDir, imposterConfig)
+	require.Len(t, configs, 1)
+
+	// Defined var is substituted; undefined reference is left intact
+	require.Equal(t, "value and ${var.unknown}", configs[0].Resources[0].Response.Content)
+}
+
 func TestLoadConfig_WithAutoBasePath(t *testing.T) {
 	// Set up auto base path and recursive scanning environment variables
 	os.Setenv("IMPOSTER_AUTO_BASE_PATH", "true")

--- a/internal/config/model.go
+++ b/internal/config/model.go
@@ -391,13 +391,14 @@ func getDefaultValidationBehaviour() ValidationBehaviour {
 
 // Config represents the configuration for an Imposter mock server
 type Config struct {
-	Plugin       string          `yaml:"plugin"`
-	BasePath     string          `yaml:"basePath,omitempty"`
-	Resources    []Resource      `yaml:"resources,omitempty"`
-	Interceptors []Interceptor   `yaml:"interceptors"`
-	System       *System         `yaml:"system,omitempty"`
-	Security     *SecurityConfig `yaml:"security"`
-	Cors         *CorsConfig     `yaml:"cors,omitempty"`
+	Plugin       string            `yaml:"plugin"`
+	BasePath     string            `yaml:"basePath,omitempty"`
+	Vars         map[string]string `yaml:"vars,omitempty"`
+	Resources    []Resource        `yaml:"resources,omitempty"`
+	Interceptors []Interceptor     `yaml:"interceptors"`
+	System       *System           `yaml:"system,omitempty"`
+	Security     *SecurityConfig   `yaml:"security"`
+	Cors         *CorsConfig       `yaml:"cors,omitempty"`
 
 	// SOAP-specific fields
 	WSDLFile string `yaml:"wsdlFile,omitempty"`


### PR DESCRIPTION
Add a top-level `vars` section to configuration files whose entries can be referenced inline via `${var.NAME}`, resolved at config parse time.

## Summary
- Add `Vars map[string]string` field to the top-level `Config` struct
- Substitute `${var.NAME}` and `${var.NAME:-default}` references at parse time, immediately after the existing `${env.VAR}` substitution
- Aggregate `vars` from every YAML document in a file (later documents win on key collisions) so multi-document configs share a single namespace
- Log a warning and leave the placeholder intact when an undefined variable is referenced without a default, to aid debugging
- Document the new syntax in `docs/env_vars.md`

## Implementation details
Substitution operates on the raw file bytes before YAML unmarshal, so it works in any string-valued field (paths, response content/file, headers, etc.) across all plugins with no engine or runtime changes — matching the issue's "config parsing layer only" scope. Environment variables are substituted first, which means a `vars` value may itself contain an `${env.VAR}` reference.

Closes #68