### PR TITLE
fix: apply basePath to interceptor paths

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -162,6 +162,17 @@ func LoadConfig(configDir string, imposterConfig *ImposterConfig) []Config {
 					}
 				}
 
+				// Prefix interceptor paths with basePath, mirroring resources.
+				// An interceptor without a path matches all requests, so only
+				// prefix the base path when a path is actually configured.
+				if fileConfig.BasePath != "" {
+					for i := range fileConfig.Interceptors {
+						if fileConfig.Interceptors[i].Path != "" {
+							fileConfig.Interceptors[i].Path = urlpath.Join(fileConfig.BasePath, fileConfig.Interceptors[i].Path)
+						}
+					}
+				}
+
 				if fileConfig.Plugin == "openapi" {
 					// Resolve OpenAPI spec path relative to config file
 					if fileConfig.SpecFile != "" && !filepath.IsAbs(fileConfig.SpecFile) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -431,6 +431,45 @@ resources:
 	require.True(t, metrics.Continue)
 }
 
+func TestLoadConfig_InterceptorsWithBasePath(t *testing.T) {
+	tempDir := t.TempDir()
+
+	imposterConfig := &ImposterConfig{}
+
+	configContent := `plugin: rest
+basePath: /api/v1
+interceptors:
+  - path: /auth
+    method: POST
+    continue: false
+  - method: GET
+    continue: true
+resources:
+  - path: /test
+    response:
+      content: test response
+      statusCode: 200`
+
+	err := os.WriteFile(filepath.Join(tempDir, "test-config.yaml"), []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	configs := LoadConfig(tempDir, imposterConfig)
+	require.Len(t, configs, 1)
+
+	cfg := configs[0]
+	require.Equal(t, "/api/v1", cfg.BasePath)
+	require.Len(t, cfg.Interceptors, 2)
+
+	// Interceptor with a path should be prefixed with the basePath
+	require.Equal(t, "/api/v1/auth", cfg.Interceptors[0].Path)
+
+	// Interceptor without a path matches all requests and must not be prefixed
+	require.Equal(t, "", cfg.Interceptors[1].Path)
+
+	// Resource paths should also be prefixed, as before
+	require.Equal(t, "/api/v1/test", cfg.Resources[0].Path)
+}
+
 func TestLoadConfig_WithSystem(t *testing.T) {
 	// Create a temporary directory for test files
 	tempDir := t.TempDir()


### PR DESCRIPTION
Interceptor paths are now prefixed with the configured `basePath`, matching how resource paths are already handled.

Also see https://github.com/imposter-project/imposter-jvm-engine/pull/25

## Summary
- Apply `basePath` to interceptor paths during config loading, mirroring the existing resource path prefixing
- Leave path-less interceptors untouched — they match all requests, and prefixing them would silently turn them into exact matches on the base path
- Added `TestLoadConfig_InterceptorsWithBasePath` covering both prefixed and match-all cases