### PR TITLE
feat: add passthrough/upstream proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A Go implementation of the [Imposter Mock Engine](https://www.imposter.sh). This
 - ✅ JavaScript [scripting](https://docs.imposter.sh/scripting/)
 - ✅ Support for [steps](https://docs.imposter.sh/steps/)
 - ✅ Support for [simulated delays](https://docs.imposter.sh/performance_simulation/), [simulated errors](https://docs.imposter.sh/failure_simulation/) and [rate limiting](./docs/rate_limiting.md)
+- ✅ Support for [passthrough/proxy to upstream services](./docs/passthrough.md)
 
 ## ⚠️ Limitations
 

--- a/TODO.md
+++ b/TODO.md
@@ -4,4 +4,3 @@ This is a non-exhaustive list of ideas for future development.
 - add support for pulling config from a remote git repo
 - add support for pulling config from a remote http(s) server
 - detect and hard fail if a config file specifies steps (script, remote)
-- add support for passthrough responses to upstreams

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -68,6 +68,15 @@ When TLS is enabled, the default `IMPOSTER_SERVER_URL` scheme becomes `https`, a
 |----------|---------|---------------|---------|
 | `IMPOSTER_RATE_LIMITER_TTL` | Rate limiter data TTL (seconds) | `300` (5 minutes) | `IMPOSTER_RATE_LIMITER_TTL=600` |
 
+## Passthrough / Upstream Proxy
+
+See [passthrough.md](./passthrough.md) for details on the feature.
+
+| Variable | Purpose | Default Value | Example |
+|----------|---------|---------------|---------|
+| `IMPOSTER_PASSTHROUGH_TIMEOUT` | Timeout for requests forwarded to an upstream (Go duration syntax) | `30s` | `IMPOSTER_PASSTHROUGH_TIMEOUT=5s` |
+| `IMPOSTER_PASSTHROUGH_FORWARDED_HEADERS` | Inject `X-Forwarded-For`, `X-Forwarded-Host`, `X-Forwarded-Proto` and `Via` headers into forwarded requests | `false` | `IMPOSTER_PASSTHROUGH_FORWARDED_HEADERS=true` |
+
 ## OpenAPI
 
 | Variable | Purpose | Default Value | Example |

--- a/docs/passthrough.md
+++ b/docs/passthrough.md
@@ -1,0 +1,91 @@
+# Passthrough / Upstream Proxy
+
+Passthrough lets Imposter forward a matched request to a real upstream HTTP service and return the upstream's response verbatim, instead of serving a mocked response. This is useful for partial mocking — mocking some endpoints while proxying others to a live backend.
+
+This is the Go engine's equivalent of the JVM engine's passthrough feature, and uses the same configuration schema, so a single config file works across both engines.
+
+## Overview
+
+- **Named upstreams**: define upstream services once at the top level under `upstreams`.
+- **Per-resource opt-in**: a resource forwards to an upstream by setting `passthrough: <upstream-name>`.
+- **Verbatim forwarding**: the request method, path, query string, headers and body are forwarded; the upstream's status code, headers and body are returned to the client.
+- **Mutually exclusive**: when a resource declares `passthrough`, normal response processing is bypassed — `response`, `steps`, `capture` and templating are not applied.
+
+## Configuration
+
+```yaml
+plugin: rest
+
+upstreams:
+  myBackend:
+    url: "http://upstream-api.example.com"
+  secondService:
+    url: "http://another-api.example.com:8080/api"
+
+resources:
+  - path: /api/users
+    method: GET
+    passthrough: myBackend
+
+  - path: /api/products
+    method: GET
+    passthrough: secondService
+```
+
+In this example a `GET /api/users` request is forwarded to `http://upstream-api.example.com/api/users`, and a `GET /api/products` request is forwarded to `http://another-api.example.com:8080/api/products`.
+
+### Path joining
+
+The upstream's base path (if any) is prefixed to the incoming request path:
+
+| Upstream `url` | Request path | Forwarded to |
+|----------------|--------------|--------------|
+| `http://api/v1` | `/users` | `http://api/v1/users` |
+| `http://api/v1/` | `/users` | `http://api/v1/users` |
+| `http://api` | `/v1/users` | `http://api/v1/users` |
+
+The request's query string is forwarded unchanged.
+
+## Header handling
+
+All request and response headers are forwarded, except the following hop-by-hop headers (per RFC 2616 §13.5.1, plus `Accept-Encoding` and `Host`):
+
+`Accept-Encoding`, `Host`, `Connection`, `Keep-Alive`, `Proxy-Authenticate`, `Proxy-Authorization`, `TE`, `Trailers`, `Transfer-Encoding`, `Upgrade`.
+
+The `Host` header sent to the upstream is derived from the upstream URL.
+
+### Forwarded headers (optional)
+
+Proxy-style headers are **not** added by default. Set `IMPOSTER_PASSTHROUGH_FORWARDED_HEADERS=true` to inject:
+
+- `X-Forwarded-For` — the client IP (appended to any existing value)
+- `X-Forwarded-Host` — the original `Host` header
+- `X-Forwarded-Proto` — `http` or `https`
+- `Via` — `1.1 imposter`
+
+## Timeouts and errors
+
+The request to the upstream uses a default timeout of 30 seconds, overridable via `IMPOSTER_PASSTHROUGH_TIMEOUT` (Go duration syntax, e.g. `5s`, `1m`).
+
+| Condition | Response to client |
+|-----------|--------------------|
+| Upstream reachable, returns any status | The upstream status, headers and body are returned verbatim (including 4xx/5xx). |
+| Upstream unreachable, times out, or connection refused | `502 Bad Gateway` |
+| Resource references an upstream name that is not defined | Startup fails with a validation error. |
+
+## System endpoints
+
+Imposter's own system endpoints (paths under `/system`, such as `/system/status` and `/system/store`) are handled before passthrough is evaluated and are never forwarded to an upstream.
+
+## Environment variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `IMPOSTER_PASSTHROUGH_TIMEOUT` | `30s` | Timeout for the forwarded upstream request. |
+| `IMPOSTER_PASSTHROUGH_FORWARDED_HEADERS` | `false` | When `true`, inject `X-Forwarded-*` and `Via` headers. |
+
+## Limitations
+
+- Passthrough is supported on resources only; declaring it on an interceptor is ignored (a warning is logged at startup).
+- The upstream URL is static; it is not templated.
+- The upstream response is not captured into stores and is not run through response templates.

--- a/examples/rest/passthrough/README.md
+++ b/examples/rest/passthrough/README.md
@@ -1,0 +1,71 @@
+# Passthrough / Upstream Proxy Example
+
+Demonstrates the partial-mocking pattern: mock a subset of endpoints locally
+and forward the rest to a real upstream service.
+
+## How it works
+
+`upstreams` defines a named backend (`jsonplaceholder`). Resources can either
+serve a mocked response as usual, or set `passthrough: <upstream-name>` to
+forward the matched request to that upstream and return its response verbatim.
+
+When a request matches both an exact-path resource and a wildcard one, the
+exact path wins — so `/users/1` returns the local fixture while `/users/2`,
+`/users/3` etc. fall through to the wildcard and get proxied.
+
+See [docs/passthrough.md](../../../docs/passthrough.md) for the full feature
+reference.
+
+## Running
+
+From this directory:
+
+```bash
+imposter -d .
+```
+
+The example requires outbound network access to `https://jsonplaceholder.typicode.com`.
+
+## Testing
+
+`/users/1` is served from the local mock:
+
+```bash
+curl http://localhost:8080/users/1
+# {
+#   "id": 1,
+#   "name": "Locally Mocked User",
+#   "email": "mock@example.com"
+# }
+```
+
+Any other user ID is proxied to the upstream:
+
+```bash
+curl http://localhost:8080/users/2
+# {"id": 2, "name": "Ervin Howell", ...}   ← from jsonplaceholder.typicode.com
+```
+
+Posts are proxied wholesale:
+
+```bash
+curl http://localhost:8080/posts/1
+# {"userId": 1, "id": 1, "title": "...", "body": "..."}
+```
+
+## Features demonstrated
+
+1. **Named upstreams** — top-level `upstreams` map declaring backend URLs
+2. **Per-resource opt-in** — a resource forwards by setting
+   `passthrough: <name>`; without it, the resource serves a mocked response
+3. **Partial mocking** — exact-path mock plus a wildcard passthrough lets you
+   override individual endpoints while proxying the rest
+4. **Verbatim forwarding** — the upstream's status, headers and body are
+   returned to the client; `response`, `steps` and templating are bypassed for
+   passthrough resources
+
+## Environment variables
+
+- `IMPOSTER_PASSTHROUGH_TIMEOUT` — override the 30s upstream timeout
+- `IMPOSTER_PASSTHROUGH_FORWARDED_HEADERS=true` — inject `X-Forwarded-*` and
+  `Via` headers on proxied requests

--- a/examples/rest/passthrough/imposter-config.yaml
+++ b/examples/rest/passthrough/imposter-config.yaml
@@ -1,0 +1,33 @@
+plugin: rest
+
+upstreams:
+  # Public test API used here to make the example self-contained.
+  jsonplaceholder:
+    url: "https://jsonplaceholder.typicode.com"
+
+resources:
+  # Mocked locally — overrides the upstream for a single user. The exact path
+  # outscores the wildcard below, so /users/1 returns this fixture.
+  - method: GET
+    path: /users/1
+    response:
+      content: |
+        {
+          "id": 1,
+          "name": "Locally Mocked User",
+          "email": "mock@example.com"
+        }
+      statusCode: 200
+      headers:
+        Content-Type: application/json
+
+  # Anything else under /users is forwarded to the real upstream verbatim.
+  - method: GET
+    path: /users/*
+    passthrough: jsonplaceholder
+
+  # All posts are forwarded — useful when you only care about mocking part of
+  # the surface area and want the rest to behave like the real service.
+  - method: GET
+    path: /posts/*
+    passthrough: jsonplaceholder

--- a/internal/config/model.go
+++ b/internal/config/model.go
@@ -27,6 +27,12 @@ type Response struct {
 	ExampleName string `yaml:"exampleName"`
 }
 
+// Upstream defines a named upstream service that requests can be proxied to
+// when a resource declares a matching `passthrough` value.
+type Upstream struct {
+	URL string `yaml:"url"`
+}
+
 // Delay represents the delay configuration for a response
 type Delay struct {
 	Exact int `yaml:"exact"`
@@ -227,6 +233,7 @@ type BaseResource struct {
 	Response         *Response          `yaml:"response,omitempty"`
 	Concurrency      []ConcurrencyLimit `yaml:"concurrency,omitempty"`
 	Log              string             `yaml:"log,omitempty"`
+	Passthrough      string             `yaml:"passthrough,omitempty"`
 	RuntimeGenerated bool               `yaml:"-"`
 
 	// ResourceID is computed at startup
@@ -391,14 +398,15 @@ func getDefaultValidationBehaviour() ValidationBehaviour {
 
 // Config represents the configuration for an Imposter mock server
 type Config struct {
-	Plugin       string            `yaml:"plugin"`
-	BasePath     string            `yaml:"basePath,omitempty"`
-	Vars         map[string]string `yaml:"vars,omitempty"`
-	Resources    []Resource        `yaml:"resources,omitempty"`
-	Interceptors []Interceptor     `yaml:"interceptors"`
-	System       *System           `yaml:"system,omitempty"`
-	Security     *SecurityConfig   `yaml:"security"`
-	Cors         *CorsConfig       `yaml:"cors,omitempty"`
+	Plugin       string              `yaml:"plugin"`
+	BasePath     string              `yaml:"basePath,omitempty"`
+	Vars         map[string]string   `yaml:"vars,omitempty"`
+	Resources    []Resource          `yaml:"resources,omitempty"`
+	Interceptors []Interceptor       `yaml:"interceptors"`
+	Upstreams    map[string]Upstream `yaml:"upstreams,omitempty"`
+	System       *System             `yaml:"system,omitempty"`
+	Security     *SecurityConfig     `yaml:"security"`
+	Cors         *CorsConfig         `yaml:"cors,omitempty"`
 
 	// SOAP-specific fields
 	WSDLFile string `yaml:"wsdlFile,omitempty"`

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/imposter-project/imposter-go/pkg/logger"
+)
+
+// Validate checks the static integrity of a loaded config, focusing on the
+// upstream/passthrough configuration. It returns an error for conditions that
+// should prevent startup, and logs warnings for recoverable issues.
+func Validate(cfg *Config) error {
+	for name, upstream := range cfg.Upstreams {
+		u, err := url.Parse(upstream.URL)
+		if err != nil {
+			return fmt.Errorf("upstream %q has an invalid URL %q: %w", name, upstream.URL, err)
+		}
+		if u.Scheme == "" || u.Host == "" {
+			return fmt.Errorf("upstream %q URL %q must include a scheme and host", name, upstream.URL)
+		}
+	}
+
+	for i := range cfg.Resources {
+		res := &cfg.Resources[i]
+		if res.Passthrough == "" {
+			continue
+		}
+		if _, ok := cfg.Upstreams[res.Passthrough]; !ok {
+			return fmt.Errorf("resource (path %q) references unknown upstream %q", res.Path, res.Passthrough)
+		}
+		if res.Response != nil || len(res.Steps) > 0 {
+			logger.Warnf("resource (path %q) declares passthrough %q alongside a response or steps; passthrough takes precedence", res.Path, res.Passthrough)
+		}
+	}
+
+	for i := range cfg.Interceptors {
+		if cfg.Interceptors[i].Passthrough != "" {
+			logger.Warnf("interceptor (path %q) declares passthrough %q, which is not supported and will be ignored", cfg.Interceptors[i].Path, cfg.Interceptors[i].Passthrough)
+		}
+	}
+
+	return nil
+}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -1,0 +1,50 @@
+package config
+
+import "testing"
+
+func TestValidateUpstreams(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr bool
+	}{
+		{
+			name: "valid upstream and passthrough reference",
+			cfg: Config{
+				Upstreams: map[string]Upstream{"backend": {URL: "http://api.example.com"}},
+				Resources: []Resource{{BaseResource: BaseResource{Passthrough: "backend"}}},
+			},
+		},
+		{
+			name: "unknown upstream reference",
+			cfg: Config{
+				Upstreams: map[string]Upstream{"backend": {URL: "http://api.example.com"}},
+				Resources: []Resource{{BaseResource: BaseResource{Passthrough: "missing"}}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "upstream URL missing scheme",
+			cfg: Config{
+				Upstreams: map[string]Upstream{"backend": {URL: "api.example.com"}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "no passthrough config is valid",
+			cfg:  Config{Resources: []Resource{{BaseResource: BaseResource{}}}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Validate(&tt.cfg)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/internal/passthrough/passthrough.go
+++ b/internal/passthrough/passthrough.go
@@ -65,10 +65,13 @@ func forwardedHeadersEnabled() bool {
 // writes the upstream response (status, headers, body) into exch.ResponseState.
 // Normal response processing (templates, scripts, captures) is bypassed.
 //
+// upstreamName is the configured key (e.g. "myBackend") and is used only for
+// log output; it has no semantic effect.
+//
 // A non-nil error indicates a transport-level failure reaching the upstream;
 // the caller is responsible for translating that into a 502 response. A 4xx or
 // 5xx status returned by the upstream is forwarded verbatim and is not an error.
-func Proxy(exch *exchange.Exchange, upstream config.Upstream) error {
+func Proxy(exch *exchange.Exchange, upstreamName string, upstream config.Upstream) error {
 	srcReq := exch.Request.Request
 
 	targetURL, err := JoinURL(upstream.URL, srcReq.URL.Path, srcReq.URL.RawQuery)
@@ -86,7 +89,8 @@ func Proxy(exch *exchange.Exchange, upstream config.Upstream) error {
 		addForwardedHeaders(srcReq, outReq)
 	}
 
-	logger.Debugf("forwarding request to upstream %s", targetURL)
+	logger.Infof("forwarding to upstream %q - method:%s, url:%s", upstreamName, srcReq.Method, targetURL)
+	start := time.Now()
 	resp, err := getClient().Do(outReq)
 	if err != nil {
 		return fmt.Errorf("failed to forward request to upstream %s: %w", targetURL, err)
@@ -97,6 +101,8 @@ func Proxy(exch *exchange.Exchange, upstream config.Upstream) error {
 	if err != nil {
 		return fmt.Errorf("failed to read upstream response from %s: %w", targetURL, err)
 	}
+
+	logger.Infof("upstream %q responded - status:%d, length:%d, took:%s", upstreamName, resp.StatusCode, len(body), time.Since(start).Round(time.Millisecond))
 
 	rs := exch.ResponseState
 	rs.StatusCode = resp.StatusCode

--- a/internal/passthrough/passthrough.go
+++ b/internal/passthrough/passthrough.go
@@ -1,0 +1,170 @@
+package passthrough
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/imposter-project/imposter-go/internal/config"
+	"github.com/imposter-project/imposter-go/internal/exchange"
+	"github.com/imposter-project/imposter-go/pkg/logger"
+)
+
+const defaultTimeout = 30 * time.Second
+
+// HopByHopHeaders are headers that must not be forwarded in either direction.
+// Per RFC 2616 §13.5.1, plus Accept-Encoding and Host, matching the JVM engine.
+var HopByHopHeaders = map[string]struct{}{
+	"Accept-Encoding":     {},
+	"Host":                {},
+	"Connection":          {},
+	"Keep-Alive":          {},
+	"Proxy-Authenticate":  {},
+	"Proxy-Authorization": {},
+	"Te":                  {},
+	"Trailers":            {},
+	"Transfer-Encoding":   {},
+	"Upgrade":             {},
+}
+
+var (
+	clientOnce sync.Once
+	httpClient *http.Client
+)
+
+// getClient lazily constructs the shared HTTP client used for forwarding,
+// honouring the IMPOSTER_PASSTHROUGH_TIMEOUT environment variable.
+func getClient() *http.Client {
+	clientOnce.Do(func() {
+		timeout := defaultTimeout
+		if raw := os.Getenv("IMPOSTER_PASSTHROUGH_TIMEOUT"); raw != "" {
+			if d, err := time.ParseDuration(raw); err == nil {
+				timeout = d
+			} else {
+				logger.Warnf("invalid IMPOSTER_PASSTHROUGH_TIMEOUT %q, using default %s", raw, defaultTimeout)
+			}
+		}
+		httpClient = &http.Client{Timeout: timeout}
+	})
+	return httpClient
+}
+
+// forwardedHeadersEnabled reports whether X-Forwarded-* and Via headers should
+// be injected into upstream requests.
+func forwardedHeadersEnabled() bool {
+	return strings.EqualFold(os.Getenv("IMPOSTER_PASSTHROUGH_FORWARDED_HEADERS"), "true")
+}
+
+// Proxy forwards the incoming request held in exch to the given upstream and
+// writes the upstream response (status, headers, body) into exch.ResponseState.
+// Normal response processing (templates, scripts, captures) is bypassed.
+//
+// A non-nil error indicates a transport-level failure reaching the upstream;
+// the caller is responsible for translating that into a 502 response. A 4xx or
+// 5xx status returned by the upstream is forwarded verbatim and is not an error.
+func Proxy(exch *exchange.Exchange, upstream config.Upstream) error {
+	srcReq := exch.Request.Request
+
+	targetURL, err := JoinURL(upstream.URL, srcReq.URL.Path, srcReq.URL.RawQuery)
+	if err != nil {
+		return err
+	}
+
+	outReq, err := http.NewRequest(srcReq.Method, targetURL, bytes.NewReader(exch.Request.Body))
+	if err != nil {
+		return fmt.Errorf("failed to create upstream request: %w", err)
+	}
+
+	copyRequestHeaders(srcReq, outReq)
+	if forwardedHeadersEnabled() {
+		addForwardedHeaders(srcReq, outReq)
+	}
+
+	logger.Debugf("forwarding request to upstream %s", targetURL)
+	resp, err := getClient().Do(outReq)
+	if err != nil {
+		return fmt.Errorf("failed to forward request to upstream %s: %w", targetURL, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read upstream response from %s: %w", targetURL, err)
+	}
+
+	rs := exch.ResponseState
+	rs.StatusCode = resp.StatusCode
+	copyResponseHeaders(resp.Header, rs)
+	rs.Body = body
+	return nil
+}
+
+// copyRequestHeaders copies all non-hop-by-hop headers from the incoming
+// request onto the outgoing upstream request.
+func copyRequestHeaders(src *http.Request, dst *http.Request) {
+	for key, values := range src.Header {
+		if isHopByHop(key) {
+			continue
+		}
+		for _, v := range values {
+			dst.Header.Add(key, v)
+		}
+	}
+}
+
+// copyResponseHeaders copies all non-hop-by-hop upstream response headers onto
+// the response state. As ResponseState.Headers is single-valued, repeated
+// header values are joined with ", ".
+func copyResponseHeaders(src http.Header, rs *exchange.ResponseState) {
+	if rs.Headers == nil {
+		rs.Headers = make(map[string]string)
+	}
+	for key, values := range src {
+		if isHopByHop(key) {
+			continue
+		}
+		rs.Headers[key] = strings.Join(values, ", ")
+	}
+}
+
+// addForwardedHeaders injects proxy-style headers so the upstream can identify
+// the original client and protocol.
+func addForwardedHeaders(src *http.Request, dst *http.Request) {
+	if clientIP := clientIP(src.RemoteAddr); clientIP != "" {
+		if prior := src.Header.Get("X-Forwarded-For"); prior != "" {
+			dst.Header.Set("X-Forwarded-For", prior+", "+clientIP)
+		} else {
+			dst.Header.Set("X-Forwarded-For", clientIP)
+		}
+	}
+	if src.Host != "" {
+		dst.Header.Set("X-Forwarded-Host", src.Host)
+	}
+	proto := "http"
+	if src.TLS != nil {
+		proto = "https"
+	}
+	dst.Header.Set("X-Forwarded-Proto", proto)
+	dst.Header.Set("Via", "1.1 imposter")
+}
+
+func clientIP(remoteAddr string) string {
+	if remoteAddr == "" {
+		return ""
+	}
+	if host, _, err := net.SplitHostPort(remoteAddr); err == nil {
+		return host
+	}
+	return remoteAddr
+}
+
+func isHopByHop(header string) bool {
+	_, ok := HopByHopHeaders[http.CanonicalHeaderKey(header)]
+	return ok
+}

--- a/internal/passthrough/passthrough_test.go
+++ b/internal/passthrough/passthrough_test.go
@@ -1,0 +1,151 @@
+package passthrough
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/imposter-project/imposter-go/internal/config"
+	"github.com/imposter-project/imposter-go/internal/exchange"
+	"github.com/imposter-project/imposter-go/internal/response"
+	"github.com/imposter-project/imposter-go/internal/store"
+)
+
+// newExchange builds an Exchange around an inbound request for testing.
+func newExchange(req *http.Request, body []byte) *exchange.Exchange {
+	return exchange.NewExchange(req, body, store.NewRequestStore(), response.NewResponseState())
+}
+
+func TestProxyForwardsRequestAndReturnsResponse(t *testing.T) {
+	var capturedPath, capturedQuery, capturedBody string
+	var capturedHeaders http.Header
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedQuery = r.URL.RawQuery
+		capturedHeaders = r.Header.Clone()
+		b, _ := io.ReadAll(r.Body)
+		capturedBody = string(b)
+
+		w.Header().Set("X-Upstream", "yes")
+		w.Header().Set("Connection", "keep-alive") // hop-by-hop, must be stripped
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte("hello from upstream"))
+	}))
+	defer upstream.Close()
+
+	body := []byte(`{"k":"v"}`)
+	req := httptest.NewRequest(http.MethodPost, "http://mock.local/api/users?page=2", strings.NewReader(string(body)))
+	req.Header.Set("X-Trace-Id", "abc123")
+	req.Header.Set("Accept-Encoding", "br") // hop-by-hop, must be stripped
+
+	exch := newExchange(req, body)
+	if err := Proxy(exch, config.Upstream{URL: upstream.URL + "/base"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if capturedPath != "/base/api/users" {
+		t.Errorf("upstream path = %q, want %q", capturedPath, "/base/api/users")
+	}
+	if capturedQuery != "page=2" {
+		t.Errorf("upstream query = %q, want %q", capturedQuery, "page=2")
+	}
+	if capturedBody != string(body) {
+		t.Errorf("upstream body = %q, want %q", capturedBody, string(body))
+	}
+	if capturedHeaders.Get("X-Trace-Id") != "abc123" {
+		t.Errorf("expected X-Trace-Id forwarded, headers: %v", capturedHeaders)
+	}
+	// The client's Accept-Encoding must not be forwarded. Go's transport may
+	// transparently add its own "gzip" value, but our distinctive "br" must be gone.
+	if strings.Contains(capturedHeaders.Get("Accept-Encoding"), "br") {
+		t.Errorf("expected client Accept-Encoding stripped, got %q", capturedHeaders.Get("Accept-Encoding"))
+	}
+
+	rs := exch.ResponseState
+	if rs.StatusCode != http.StatusCreated {
+		t.Errorf("status = %d, want %d", rs.StatusCode, http.StatusCreated)
+	}
+	if string(rs.Body) != "hello from upstream" {
+		t.Errorf("body = %q, want %q", rs.Body, "hello from upstream")
+	}
+	if rs.Headers["X-Upstream"] != "yes" {
+		t.Errorf("expected X-Upstream header forwarded, got %v", rs.Headers)
+	}
+	if _, ok := rs.Headers["Connection"]; ok {
+		t.Errorf("expected Connection header stripped from response, got %v", rs.Headers)
+	}
+}
+
+func TestProxyForwardsUpstreamErrorStatusVerbatim(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("upstream boom"))
+	}))
+	defer upstream.Close()
+
+	req := httptest.NewRequest(http.MethodGet, "http://mock.local/thing", nil)
+	exch := newExchange(req, nil)
+
+	if err := Proxy(exch, config.Upstream{URL: upstream.URL}); err != nil {
+		t.Fatalf("an upstream 5xx must not be a transport error, got: %v", err)
+	}
+	if exch.ResponseState.StatusCode != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", exch.ResponseState.StatusCode, http.StatusInternalServerError)
+	}
+	if string(exch.ResponseState.Body) != "upstream boom" {
+		t.Errorf("body = %q, want %q", exch.ResponseState.Body, "upstream boom")
+	}
+}
+
+func TestProxyTransportFailureReturnsError(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "http://mock.local/thing", nil)
+	exch := newExchange(req, nil)
+
+	// Port 1 is not listening; the dial should fail.
+	if err := Proxy(exch, config.Upstream{URL: "http://127.0.0.1:1"}); err == nil {
+		t.Fatal("expected a transport error, got nil")
+	}
+}
+
+func TestProxyForwardedHeaders(t *testing.T) {
+	var captured http.Header
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	req := httptest.NewRequest(http.MethodGet, "http://mock.local/thing", nil)
+	req.RemoteAddr = "203.0.113.7:54321"
+	req.Host = "mock.local"
+
+	// Disabled by default.
+	t.Setenv("IMPOSTER_PASSTHROUGH_FORWARDED_HEADERS", "")
+	if err := Proxy(newExchange(req, nil), config.Upstream{URL: upstream.URL}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.Get("X-Forwarded-For") != "" {
+		t.Errorf("expected no X-Forwarded-For when disabled, got %q", captured.Get("X-Forwarded-For"))
+	}
+
+	// Enabled via env var.
+	t.Setenv("IMPOSTER_PASSTHROUGH_FORWARDED_HEADERS", "true")
+	if err := Proxy(newExchange(req, nil), config.Upstream{URL: upstream.URL}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := captured.Get("X-Forwarded-For"); got != "203.0.113.7" {
+		t.Errorf("X-Forwarded-For = %q, want %q", got, "203.0.113.7")
+	}
+	if got := captured.Get("X-Forwarded-Host"); got != "mock.local" {
+		t.Errorf("X-Forwarded-Host = %q, want %q", got, "mock.local")
+	}
+	if got := captured.Get("X-Forwarded-Proto"); got != "http" {
+		t.Errorf("X-Forwarded-Proto = %q, want %q", got, "http")
+	}
+	if got := captured.Get("Via"); got != "1.1 imposter" {
+		t.Errorf("Via = %q, want %q", got, "1.1 imposter")
+	}
+}

--- a/internal/passthrough/passthrough_test.go
+++ b/internal/passthrough/passthrough_test.go
@@ -42,7 +42,7 @@ func TestProxyForwardsRequestAndReturnsResponse(t *testing.T) {
 	req.Header.Set("Accept-Encoding", "br") // hop-by-hop, must be stripped
 
 	exch := newExchange(req, body)
-	if err := Proxy(exch, config.Upstream{URL: upstream.URL + "/base"}); err != nil {
+	if err := Proxy(exch, "test", config.Upstream{URL: upstream.URL + "/base"}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -89,7 +89,7 @@ func TestProxyForwardsUpstreamErrorStatusVerbatim(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "http://mock.local/thing", nil)
 	exch := newExchange(req, nil)
 
-	if err := Proxy(exch, config.Upstream{URL: upstream.URL}); err != nil {
+	if err := Proxy(exch, "test", config.Upstream{URL: upstream.URL}); err != nil {
 		t.Fatalf("an upstream 5xx must not be a transport error, got: %v", err)
 	}
 	if exch.ResponseState.StatusCode != http.StatusInternalServerError {
@@ -105,7 +105,7 @@ func TestProxyTransportFailureReturnsError(t *testing.T) {
 	exch := newExchange(req, nil)
 
 	// Port 1 is not listening; the dial should fail.
-	if err := Proxy(exch, config.Upstream{URL: "http://127.0.0.1:1"}); err == nil {
+	if err := Proxy(exch, "test", config.Upstream{URL: "http://127.0.0.1:1"}); err == nil {
 		t.Fatal("expected a transport error, got nil")
 	}
 }
@@ -124,7 +124,7 @@ func TestProxyForwardedHeaders(t *testing.T) {
 
 	// Disabled by default.
 	t.Setenv("IMPOSTER_PASSTHROUGH_FORWARDED_HEADERS", "")
-	if err := Proxy(newExchange(req, nil), config.Upstream{URL: upstream.URL}); err != nil {
+	if err := Proxy(newExchange(req, nil), "test", config.Upstream{URL: upstream.URL}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if captured.Get("X-Forwarded-For") != "" {
@@ -133,7 +133,7 @@ func TestProxyForwardedHeaders(t *testing.T) {
 
 	// Enabled via env var.
 	t.Setenv("IMPOSTER_PASSTHROUGH_FORWARDED_HEADERS", "true")
-	if err := Proxy(newExchange(req, nil), config.Upstream{URL: upstream.URL}); err != nil {
+	if err := Proxy(newExchange(req, nil), "test", config.Upstream{URL: upstream.URL}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if got := captured.Get("X-Forwarded-For"); got != "203.0.113.7" {

--- a/internal/passthrough/url.go
+++ b/internal/passthrough/url.go
@@ -1,0 +1,50 @@
+package passthrough
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// JoinURL combines an upstream base URL with the incoming request path and
+// query string. The upstream's base path (if any) is prefixed to the request
+// path, mirroring the JVM engine's path-joining behaviour. The raw query
+// string is forwarded verbatim without re-encoding.
+//
+// Examples:
+//
+//	base http://api/v1, path /users           -> http://api/v1/users
+//	base http://api/v1/, path /users          -> http://api/v1/users
+//	base http://api, path /v1/users           -> http://api/v1/users
+//	base http://api/v1, path /, query a=1     -> http://api/v1/?a=1
+func JoinURL(base, requestPath, rawQuery string) (string, error) {
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("invalid upstream URL %q: %w", base, err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("upstream URL %q must include a scheme and host", base)
+	}
+
+	u.Path = joinPaths(u.Path, requestPath)
+	u.RawQuery = rawQuery
+	// Avoid url.URL re-encoding the forwarded path/query.
+	u.RawPath = ""
+	return u.String(), nil
+}
+
+// joinPaths concatenates a base path and an appended path, normalising the
+// slash at the boundary while preserving a trailing slash on the result.
+func joinPaths(base, appendPath string) string {
+	if appendPath == "" {
+		return base
+	}
+	if base == "" || base == "/" {
+		return appendPath
+	}
+	base = strings.TrimSuffix(base, "/")
+	if !strings.HasPrefix(appendPath, "/") {
+		appendPath = "/" + appendPath
+	}
+	return base + appendPath
+}

--- a/internal/passthrough/url_test.go
+++ b/internal/passthrough/url_test.go
@@ -1,0 +1,43 @@
+package passthrough
+
+import "testing"
+
+func TestJoinURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		base        string
+		requestPath string
+		rawQuery    string
+		want        string
+		wantErr     bool
+	}{
+		{name: "base path joined with request path", base: "http://api/v1", requestPath: "/users", want: "http://api/v1/users"},
+		{name: "trailing slash on base normalised", base: "http://api/v1/", requestPath: "/users", want: "http://api/v1/users"},
+		{name: "no base path", base: "http://api", requestPath: "/v1/users", want: "http://api/v1/users"},
+		{name: "root request path preserves trailing slash", base: "http://api/v1", requestPath: "/", want: "http://api/v1/"},
+		{name: "query string forwarded verbatim", base: "http://api", requestPath: "/users", rawQuery: "a=1&b=two", want: "http://api/users?a=1&b=two"},
+		{name: "query not re-encoded", base: "http://api", requestPath: "/search", rawQuery: "q=a+b%20c", want: "http://api/search?q=a+b%20c"},
+		{name: "port preserved", base: "http://api:8080/base", requestPath: "/users", want: "http://api:8080/base/users"},
+		{name: "empty request path keeps base", base: "http://api/v1", requestPath: "", want: "http://api/v1"},
+		{name: "missing scheme errors", base: "api/v1", requestPath: "/users", wantErr: true},
+		{name: "missing host errors", base: "http://", requestPath: "/users", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := JoinURL(tt.base, tt.requestPath, tt.rawQuery)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (result %q)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("JoinURL(%q, %q, %q) = %q, want %q", tt.base, tt.requestPath, tt.rawQuery, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -8,6 +8,7 @@ import (
 	"github.com/imposter-project/imposter-go/internal/config"
 	"github.com/imposter-project/imposter-go/internal/exchange"
 	"github.com/imposter-project/imposter-go/internal/matcher"
+	"github.com/imposter-project/imposter-go/internal/passthrough"
 	"github.com/imposter-project/imposter-go/internal/response"
 	"github.com/imposter-project/imposter-go/internal/steps"
 	"github.com/imposter-project/imposter-go/pkg/logger"
@@ -155,6 +156,26 @@ func RunPipeline(
 		if shouldLimit {
 			return
 		}
+	}
+
+	// Forward to an upstream if the matched resource declares a passthrough.
+	// This is mutually exclusive with steps, captures, and response processing.
+	if best.Resource.Passthrough != "" {
+		upstream, ok := cfg.Upstreams[best.Resource.Passthrough]
+		if !ok {
+			logger.Errorf("resource references unknown upstream %q", best.Resource.Passthrough)
+			responseState.StatusCode = http.StatusInternalServerError
+			responseState.Body = []byte("Unknown upstream: " + best.Resource.Passthrough)
+			responseState.HandledWithResource(&best.Resource.BaseResource)
+			return
+		}
+		if err := passthrough.Proxy(exch, upstream); err != nil {
+			logger.Errorf("passthrough to %q failed: %v", best.Resource.Passthrough, err)
+			responseState.StatusCode = http.StatusBadGateway
+			responseState.Body = []byte("Upstream request failed")
+		}
+		responseState.HandledWithResource(&best.Resource.BaseResource)
+		return
 	}
 
 	// Capture request data

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -169,7 +169,7 @@ func RunPipeline(
 			responseState.HandledWithResource(&best.Resource.BaseResource)
 			return
 		}
-		if err := passthrough.Proxy(exch, upstream); err != nil {
+		if err := passthrough.Proxy(exch, best.Resource.Passthrough, upstream); err != nil {
 			logger.Errorf("passthrough to %q failed: %v", best.Resource.Passthrough, err)
 			responseState.StatusCode = http.StatusBadGateway
 			responseState.Body = []byte("Upstream request failed")

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -26,6 +26,9 @@ type Plugin interface {
 func LoadPlugins(configs []config.Config, imposterConfig *config.ImposterConfig, externalPlugins []external.LoadedPlugin) ([]Plugin, error) {
 	var plugins []Plugin
 	for _, cfg := range configs {
+		if err := config.Validate(&cfg); err != nil {
+			return nil, fmt.Errorf("invalid configuration for plugin '%s': %w", cfg.Plugin, err)
+		}
 		plg, err := loadPlugin(&cfg, imposterConfig, externalPlugins)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load plugin '%s': %w", cfg.Plugin, err)

--- a/test/passthrough_test.go
+++ b/test/passthrough_test.go
@@ -1,0 +1,140 @@
+package test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/imposter-project/imposter-go/internal/config"
+	"github.com/imposter-project/imposter-go/internal/handler"
+	"github.com/imposter-project/imposter-go/plugin"
+	"github.com/stretchr/testify/require"
+)
+
+// startPassthroughServer loads the given config content and starts an Imposter
+// test server in front of it.
+func startPassthroughServer(t *testing.T, configContent string) *httptest.Server {
+	t.Helper()
+	tempDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "test-config.yaml"), []byte(configContent), 0644))
+
+	imposterConfig := config.LoadImposterConfig()
+	configs := config.LoadConfig(tempDir, imposterConfig)
+	plugins, err := plugin.LoadPlugins(configs, imposterConfig, nil)
+	require.NoError(t, err)
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handler.HandleRequest(nil, w, r, plugins)
+	}))
+}
+
+func TestIntegration_Passthrough_HappyPath(t *testing.T) {
+	var gotPath, gotQuery, gotBody string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.Header().Set("X-Upstream", "yes")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("upstream body"))
+	}))
+	defer upstream.Close()
+
+	cfg := fmt.Sprintf(`plugin: rest
+upstreams:
+  backend:
+    url: %s/base
+resources:
+  - path: /api/users
+    method: POST
+    passthrough: backend`, upstream.URL)
+
+	server := startPassthroughServer(t, cfg)
+	defer server.Close()
+
+	resp, err := http.Post(server.URL+"/api/users?page=2", "application/json", strings.NewReader(`{"k":"v"}`))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "upstream body", string(body))
+	require.Equal(t, "yes", resp.Header.Get("X-Upstream"))
+	require.Equal(t, "/base/api/users", gotPath)
+	require.Equal(t, "page=2", gotQuery)
+	require.Equal(t, `{"k":"v"}`, gotBody)
+}
+
+func TestIntegration_Passthrough_UpstreamErrorVerbatim(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("upstream error"))
+	}))
+	defer upstream.Close()
+
+	cfg := fmt.Sprintf(`plugin: rest
+upstreams:
+  backend:
+    url: %s
+resources:
+  - path: /thing
+    method: GET
+    passthrough: backend`, upstream.URL)
+
+	server := startPassthroughServer(t, cfg)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/thing")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	require.Equal(t, "upstream error", string(body))
+}
+
+func TestIntegration_Passthrough_UpstreamDownReturns502(t *testing.T) {
+	cfg := `plugin: rest
+upstreams:
+  backend:
+    url: http://127.0.0.1:1
+resources:
+  - path: /thing
+    method: GET
+    passthrough: backend`
+
+	server := startPassthroughServer(t, cfg)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/thing")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusBadGateway, resp.StatusCode)
+}
+
+func TestIntegration_Passthrough_UnknownUpstreamFailsToLoad(t *testing.T) {
+	tempDir := t.TempDir()
+	cfg := `plugin: rest
+upstreams:
+  backend:
+    url: http://api.example.com
+resources:
+  - path: /thing
+    method: GET
+    passthrough: missing`
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "test-config.yaml"), []byte(cfg), 0644))
+
+	imposterConfig := config.LoadImposterConfig()
+	configs := config.LoadConfig(tempDir, imposterConfig)
+	_, err := plugin.LoadPlugins(configs, imposterConfig, nil)
+	require.Error(t, err)
+}


### PR DESCRIPTION
Forwards matched requests to a named upstream HTTP service and returns the response verbatim, mirroring the JVM engine's `passthrough`/`upstreams` schema so a single config works across both engines.

## Summary

- Add plugin-level `upstreams:` map and per-resource `passthrough:` field; matched requests are forwarded to the upstream with method, path (joined with the upstream's base path), query string, headers and body.
- Upstream status, headers and body are returned verbatim; normal response processing — templates, steps, captures — is bypassed.
- Hop-by-hop headers (RFC 2616 §13.5.1 plus `Accept-Encoding` and `Host`) are stripped in both directions.
- Transport failures surface as `502 Bad Gateway`; resources referencing an unknown upstream fail config validation at startup.
- Two new environment variables: `IMPOSTER_PASSTHROUGH_TIMEOUT` (default `30s`) and `IMPOSTER_PASSTHROUGH_FORWARDED_HEADERS` (default `false`, enables `X-Forwarded-For`, `X-Forwarded-Host`, `X-Forwarded-Proto` and `Via`).
- Adds `docs/passthrough.md` and updates `docs/env_vars.md`, `README.md`, `TODO.md`.

## Implementation details

- Passthrough is invoked from the pipeline after the best-match resource is selected and the rate-limit check has passed, but before captures/steps/response processing — matching the JVM engine's mutually-exclusive contract.
- The HTTP client is shared, lazily initialised, and reads `IMPOSTER_PASSTHROUGH_TIMEOUT` once at first use.
- `/system/*` endpoints are inherently excluded because the system handler runs before the pipeline.
- `passthrough` lives on `BaseResource` so the field is parseable on interceptors, but only honoured on resources in this version; a warning is logged at startup if it appears on an interceptor.
- Path joining preserves trailing slashes and forwards the raw query string verbatim (no re-encoding via `url.Values`).