### PR TITLE
fix: emit log message for continuing interceptors

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -11,6 +11,7 @@ import (
 	"github.com/imposter-project/imposter-go/internal/passthrough"
 	"github.com/imposter-project/imposter-go/internal/response"
 	"github.com/imposter-project/imposter-go/internal/steps"
+	"github.com/imposter-project/imposter-go/internal/template"
 	"github.com/imposter-project/imposter-go/pkg/logger"
 )
 
@@ -117,6 +118,14 @@ func RunPipeline(
 			if !interceptorCfg.Continue {
 				responseState.HandledWithResource(&interceptorCfg.BaseResource)
 				return
+			}
+
+			// When the interceptor continues, it will not become the handling
+			// resource, so the main handler will never log it. Emit its log
+			// message here instead, after captures and steps have run so the
+			// template can reference any data they produced.
+			if interceptorCfg.Log != "" {
+				logger.Infoln(template.ProcessTemplate(interceptorCfg.Log, exch, imposterConfig, &interceptorCfg.RequestMatcher))
 			}
 		}
 	}

--- a/test/log_test.go
+++ b/test/log_test.go
@@ -157,6 +157,65 @@ func TestInterceptorLog(t *testing.T) {
 	assert.Contains(t, logString, "Authenticated request from agent: Some-User-Agent")
 }
 
+func TestInterceptorLogWithContinue(t *testing.T) {
+	// An interceptor that continues does not become the handling resource,
+	// but its log message must still be emitted.
+	matcher := config.MatchCondition{
+		Value:    "Some-User-Agent",
+		Operator: "EqualTo",
+	}
+
+	interceptor := testutils.NewInterceptorWithLog("GET", "/secured", map[string]config.MatcherUnmarshaler{
+		"User-Agent": {Matcher: matcher},
+	}, nil, true, "Continuing request from agent: ${context.request.headers.User-Agent}")
+
+	configs := []config.Config{
+		{
+			Plugin: "rest",
+			Resources: []config.Resource{
+				testutils.NewResource("GET", "/secured", &config.Response{
+					StatusCode: 200,
+					Content:    "Protected content",
+				}),
+			},
+			Interceptors: []config.Interceptor{interceptor},
+		},
+	}
+
+	imposterConfig := &config.ImposterConfig{
+		ServerPort: "8080",
+	}
+	plugins, err := plugin.LoadPlugins(configs, imposterConfig, nil)
+	require.NoError(t, err)
+
+	// Capture log output
+	var logOutput bytes.Buffer
+	originalOutput, originalError := logger.GetSinks()
+	logger.SetOutputSink(&logOutput)
+	logger.SetErrorSink(&logOutput)
+	defer func() {
+		logger.SetOutputSink(originalOutput)
+		logger.SetErrorSink(originalError)
+	}()
+
+	req, err := http.NewRequest("GET", "/secured", new(strings.Reader))
+	require.NoError(t, err)
+	req.Header.Set("User-Agent", "Some-User-Agent")
+
+	rec := httptest.NewRecorder()
+	handler.HandleRequest(imposterConfig, rec, req, plugins)
+
+	// The downstream resource should handle the request
+	assert.Equal(t, http.StatusOK, rec.Code)
+	responseBody, err := io.ReadAll(rec.Body)
+	require.NoError(t, err)
+	assert.Equal(t, "Protected content", string(responseBody))
+
+	// The continuing interceptor's log message should still be emitted
+	logString := logOutput.String()
+	assert.Contains(t, logString, "Continuing request from agent: Some-User-Agent")
+}
+
 func TestComplexLogTemplates(t *testing.T) {
 	// Test complex template combinations in log messages
 


### PR DESCRIPTION
Ensure an interceptor's `log` message is emitted even when it allows request processing to continue.

## Summary
- A matched interceptor with `continue: true` never had its `log` message emitted. Logging was driven by the final handling resource, and a continuing interceptor never becomes that resource, so its message was silently dropped.
- Emit the interceptor's `log` message from the pipeline after captures and steps have run, so the template can reference any data they produce.
- Add a regression test covering a continuing interceptor's log alongside a downstream resource that handles the request.

## Implementation details
Short-circuiting interceptors (`continue: false`) are still logged by the main handler via the handling resource, so the new emission is scoped to the `continue: true` branch to avoid double-logging.