### PR TITLE
Fix/OIDC server discovery issuer path prefix

### DIFF
--- a/external/plugins/oidc-server/e2e_test.go
+++ b/external/plugins/oidc-server/e2e_test.go
@@ -217,7 +217,7 @@ func TestOIDCServer_EndToEndFlow(t *testing.T) {
 		requiredClaims := map[string]string{
 			"sub":   "alice",
 			"aud":   "test-client",
-			"iss":   "http://localhost:8080",
+			"iss":   "http://localhost:8080/oidc",
 			"nonce": "e2e-test-nonce-67890",
 		}
 

--- a/external/plugins/oidc-server/logout.go
+++ b/external/plugins/oidc-server/logout.go
@@ -100,8 +100,9 @@ func (o *OIDCServer) parseIDTokenHint(tokenString string) (clientID, sub string,
 
 	// Verify issuer matches this server
 	iss, _ := claims["iss"].(string)
-	if iss != o.serverURL {
-		return "", "", fmt.Errorf("issuer mismatch: expected %s, got %s", o.serverURL, iss)
+	expectedIssuer := o.serverURL + o.pathPrefix
+	if iss != expectedIssuer {
+		return "", "", fmt.Errorf("issuer mismatch: expected %s, got %s", expectedIssuer, iss)
 	}
 
 	// Extract audience (client ID) and subject (user ID)

--- a/external/plugins/oidc-server/logout_test.go
+++ b/external/plugins/oidc-server/logout_test.go
@@ -82,7 +82,7 @@ func generateTestIDToken(server *OIDCServer, sub, aud string, expired bool) stri
 	}
 
 	claims := jwt.MapClaims{
-		"iss": server.serverURL,
+		"iss": server.serverURL + server.pathPrefix,
 		"sub": sub,
 		"aud": aud,
 		"iat": now.Unix(),
@@ -249,7 +249,7 @@ func TestOIDCServer_handleLogout_IDTokenHint(t *testing.T) {
 	t.Run("invalid signature shows confirmation instead of error", func(t *testing.T) {
 		// Token signed with wrong key
 		claims := jwt.MapClaims{
-			"iss": server.serverURL,
+			"iss": server.serverURL + server.pathPrefix,
 			"sub": "alice",
 			"aud": "test-client",
 			"exp": time.Now().Add(1 * time.Hour).Unix(),
@@ -509,7 +509,7 @@ func TestOIDCServer_parseIDTokenHint(t *testing.T) {
 
 	t.Run("wrong key returns error", func(t *testing.T) {
 		claims := jwt.MapClaims{
-			"iss": server.serverURL,
+			"iss": server.serverURL + server.pathPrefix,
 			"sub": "alice",
 			"aud": "test-client",
 			"exp": time.Now().Add(1 * time.Hour).Unix(),

--- a/external/plugins/oidc-server/plugin.go
+++ b/external/plugins/oidc-server/plugin.go
@@ -241,7 +241,7 @@ func (o *OIDCServer) cacheJWKS() error {
 func (o *OIDCServer) CacheDiscoveryDocument() error {
 	// Build discovery document as a map
 	discovery := map[string]interface{}{
-		"issuer":                                o.serverURL,
+		"issuer":                                o.serverURL + o.pathPrefix,
 		"authorization_endpoint":                o.serverURL + o.pathPrefix + "/authorize",
 		"token_endpoint":                        o.serverURL + o.pathPrefix + "/token",
 		"userinfo_endpoint":                     o.serverURL + o.pathPrefix + "/userinfo",

--- a/external/plugins/oidc-server/plugin_test.go
+++ b/external/plugins/oidc-server/plugin_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"net/url"
 	"strings"
 	"testing"
@@ -553,6 +554,50 @@ func TestOIDCServer_HandleIntegration(t *testing.T) {
 		}
 		if !strings.Contains(body, "https://custom-server.com/oidc/logout") {
 			t.Error("Discovery document should contain correct end_session_endpoint")
+		}
+	})
+}
+
+// The issuer field must exactly match the URL a client would fetch the
+// discovery document from:
+// https://datatracker.ietf.org/doc/html/rfc8414#section-3.3
+// This was previously hardcoded to serverURL alone, omitting pathPrefix,
+// while every other endpoint in the same document correctly included it.
+func TestOIDCServer_CacheDiscoveryDocument_IssuerIncludesPathPrefix(t *testing.T) {
+	t.Run("default path prefix", func(t *testing.T) {
+		server := createTestOIDCServerForPlugin()
+		server.serverURL = "http://localhost:8080"
+		if err := server.CacheDiscoveryDocument(); err != nil {
+			t.Fatalf("Failed to cache discovery document: %v", err)
+		}
+
+		var discovery map[string]interface{}
+		if err := json.Unmarshal(server.cachedDiscovery, &discovery); err != nil {
+			t.Fatalf("Failed to parse discovery document: %v", err)
+		}
+
+		expectedIssuer := "http://localhost:8080/oidc"
+		if discovery["issuer"] != expectedIssuer {
+			t.Errorf("Expected issuer %q, got %q", expectedIssuer, discovery["issuer"])
+		}
+	})
+
+	t.Run("custom path prefix", func(t *testing.T) {
+		server := createTestOIDCServerForPlugin()
+		server.serverURL = "https://custom-server.com"
+		server.pathPrefix = "/custom-oidc"
+		if err := server.CacheDiscoveryDocument(); err != nil {
+			t.Fatalf("Failed to cache discovery document: %v", err)
+		}
+
+		var discovery map[string]interface{}
+		if err := json.Unmarshal(server.cachedDiscovery, &discovery); err != nil {
+			t.Fatalf("Failed to parse discovery document: %v", err)
+		}
+
+		expectedIssuer := "https://custom-server.com/custom-oidc"
+		if discovery["issuer"] != expectedIssuer {
+			t.Errorf("Expected issuer %q, got %q", expectedIssuer, discovery["issuer"])
 		}
 	})
 }

--- a/external/plugins/oidc-server/token.go
+++ b/external/plugins/oidc-server/token.go
@@ -189,7 +189,7 @@ func (o *OIDCServer) handleToken(args shared.HandlerRequest) shared.HandlerRespo
 func (o *OIDCServer) generateIDToken(user *User, clientID, nonce string, scopes []string, issuedAt time.Time, expiresIn int) (string, error) {
 	// Create JWT claims
 	claims := jwt.MapClaims{
-		"iss": o.serverURL,                                                 // issuer (use configured server URL)
+		"iss": o.serverURL + o.pathPrefix,                                  // issuer (must match discovery document's issuer)
 		"sub": user.Username,                                               // subject
 		"aud": clientID,                                                    // audience
 		"exp": issuedAt.Add(time.Duration(expiresIn) * time.Second).Unix(), // expiration

--- a/external/plugins/oidc-server/token_test.go
+++ b/external/plugins/oidc-server/token_test.go
@@ -427,8 +427,8 @@ func TestOIDCServer_generateIDToken(t *testing.T) {
 				}
 
 				claims := token.Claims.(jwt.MapClaims)
-				if claims["iss"] != "https://example.com" {
-					t.Errorf("Expected iss 'https://example.com', got '%s'", claims["iss"])
+				if claims["iss"] != "https://example.com/oidc" {
+					t.Errorf("Expected iss 'https://example.com/oidc', got '%s'", claims["iss"])
 				}
 				if claims["sub"] != "testuser" {
 					t.Errorf("Expected sub 'testuser', got '%s'", claims["sub"])


### PR DESCRIPTION
## Summary

The oidc-server plugin has a discovery document (`.well-known/openid-configuration`).
This advertises an `issuer` consisting of just a `serverURL`.
Every sibling field (`authorization_endpoint`, `token_endpoint`, `userinfo_endpoint`, `end_session_endpoint`, `jwks_uri`) , also includes a `pathPrefix`.

The default `path_prefix` is `/oidc`, so the declared issuer never matches the URL a client actually fetches from the discovery document.

This violates  [RFC 8414 §3.3](https://datatracker.ietf.org/doc/html/rfc8414#section-3.3) / OpenID Connect Discovery §4.3, which requires `issuer` to be a perfect match to the base URL used to construct the well-known URI.

It seems there was a similar gap in the ID token's `iss` claim (token.go), and the checks performed for RP-initiated logout (logout.go). I think, even if an RP skipped discovery, validation would still fail the ID token verification against a correctly configured client.

I'm hitting this right now in a project where there's some fairly good rails validation.

## What changes

This fixes all three spots together and adds a direct regression test asserting the discovery document's `issuer` against both the default and a custom path prefix.

## Archaeology

Gonna be honest, I was a bit skeptical that I've not missed something obvious about imposter or OIDC here, so I did a bit of a dive into the commit history.

Off the back of that I'm assuming this wasn't a deliberate design choice... happy to be told I'm wrong!
Sorry for the tone... got a rather pass-ag bot to help me dig through this and write it up... 😂 

Traced via `git blame`/`git log -p`:

1. **[`055c187`](https://github.com/huwd/imposter-go/commit/055c187244bae27109b72d7d0cdc7c715e488cdb)** — initial plugin. `issuer` was bare `serverURL`, and the discovery doc was served at
the root, so `issuer` correctly matched where it lived.
2. **[`c73aab2`](https://github.com/huwd/imposter-go/commit/c73aab2a4cc0e1ac84ba94baee8918db9e748c12)** ("fix(oidc): nest discovery and jwks endpoints under path prefix") — moved the
discovery/JWKS endpoints under `/oidc/`, updating `jwks_uri` and routing accordingly, but left `issuer` — two lines above `jwks_uri` in the same map literal — untouched. This is where the
mismatch began.
3. **[`0b61ef1`](https://github.com/huwd/imposter-go/commit/0b61ef14c523ac03483767bcc8e6a35c8f84d0c6)** ("feat(oidc): allow path prefix to be configured") — generalized the hardcoded
`/oidc` into a configurable `pathPrefix` across every field except `issuer`, carrying the gap forward.

## Checks added here

- [x] `go test ./external/plugins/oidc-server/...` passes
- [x] New regression test covers both default (`/oidc`) and custom path prefixes
- [x] Verified no other code path reads/writes `iss`/issuer without the fix applied (grepped the whole plugin)

## Other context

I've brought this into a personal project https://github.com/huwd/learn_hanzi/pull/386.

Ruby's openid_connect gem enforces RFC-required issuer matching between the ID token's iss claim and the client's configured issuer, with no way to disable it — that's what surfaced this.

See [here](https://github.com/nov/openid_connect/blob/v2.3.1/lib/openid_connect/response_object/id_token.rb#L26) and [here](https://github.com/omniauth/omniauth_openid_connect/blob/v0.8.0/lib/omniauth/strategies/openid_connect.rb#L473) for Ruby maintainers being good RFC citizens.

So basically this comes down to `"http://localhost:8080/oidc" != "http://localhost:8080"`

I've confirmed the gem is appeased when i run against a version of imposter using this change.