### PR TITLE
fix(oidc): normalise path prefix and guard issuer consistency

### DIFF
--- a/external/plugins/oidc-server/config.go
+++ b/external/plugins/oidc-server/config.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"gopkg.in/yaml.v3"
@@ -42,6 +43,24 @@ type Client struct {
 
 const defaultPathPrefix = "/oidc"
 
+// normalizePathPrefix cleans a user-supplied path prefix into the canonical
+// form the rest of the plugin assumes: a single leading slash and no trailing
+// slash (e.g. "oidc", "/oidc/", "  /oidc  " all become "/oidc"). Every issuer
+// and endpoint URL is built by concatenating serverURL + pathPrefix, and
+// routing matches against pathPrefix+"/", so a missing leading slash or a
+// stray trailing slash would otherwise produce a malformed issuer
+// ("https://hostoidc") or double slashes and break request matching.
+//
+// An empty or slash-only prefix falls back to the default rather than serving
+// the endpoints at the server root, preserving existing behaviour.
+func normalizePathPrefix(prefix string) string {
+	trimmed := strings.Trim(strings.TrimSpace(prefix), "/")
+	if trimmed == "" {
+		return defaultPathPrefix
+	}
+	return "/" + trimmed
+}
+
 // loadOIDCConfig loads OIDC configuration from raw YAML bytes
 // as provided by the main config system's plugin config block
 func loadOIDCConfig(pluginConfigBytes []byte) (*OIDCConfig, error) {
@@ -55,10 +74,9 @@ func loadOIDCConfig(pluginConfigBytes []byte) (*OIDCConfig, error) {
 		return nil, fmt.Errorf("failed to unmarshal plugin config: %w", err)
 	}
 
-	// Set default path prefix if not provided
-	if config.PathPrefix == "" {
-		config.PathPrefix = defaultPathPrefix
-	}
+	// Normalise the path prefix (adds leading slash, strips trailing slash,
+	// falls back to the default when empty)
+	config.PathPrefix = normalizePathPrefix(config.PathPrefix)
 
 	// Validate configuration
 	if err := validateConfig(&config); err != nil {

--- a/external/plugins/oidc-server/config_test.go
+++ b/external/plugins/oidc-server/config_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
+
+	"github.com/hashicorp/go-hclog"
 )
 
 func TestValidateConfig(t *testing.T) {
@@ -382,5 +385,85 @@ users:
 				tt.validate(t, config)
 			}
 		})
+	}
+}
+
+func TestNormalizePathPrefix(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty falls back to default", "", "/oidc"},
+		{"already canonical", "/oidc", "/oidc"},
+		{"missing leading slash", "oidc", "/oidc"},
+		{"trailing slash stripped", "/oidc/", "/oidc"},
+		{"missing leading and trailing", "oidc/", "/oidc"},
+		{"custom prefix normalised", "custom-oidc/", "/custom-oidc"},
+		{"surrounding whitespace trimmed", "  /oidc  ", "/oidc"},
+		{"nested path preserved", "/auth/oidc/", "/auth/oidc"},
+		{"duplicate edge slashes collapsed", "//oidc//", "/oidc"},
+		{"slash only falls back to default", "/", "/oidc"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizePathPrefix(tt.input); got != tt.want {
+				t.Errorf("normalizePathPrefix(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLoadOIDCConfig_NormalizesPathPrefix asserts that a messy path_prefix from
+// user YAML is normalised end-to-end, and that the resulting server builds a
+// well-formed discovery document from it (correct issuer, no double slashes).
+func TestLoadOIDCConfig_NormalizesPathPrefix(t *testing.T) {
+	configYAML := `
+path_prefix: "custom-oidc/"
+users:
+  - username: "alice"
+    password: "password"
+    claims:
+      sub: "alice"
+clients:
+  - client_id: "test-client"
+    client_secret: "test-secret"
+    redirect_uris:
+      - "https://issuer.example.com/callback"
+`
+	config, err := loadOIDCConfig([]byte(configYAML))
+	if err != nil {
+		t.Fatalf("loadOIDCConfig returned error: %v", err)
+	}
+	if config.PathPrefix != "/custom-oidc" {
+		t.Fatalf("Expected normalised path prefix '/custom-oidc', got %q", config.PathPrefix)
+	}
+
+	server := &OIDCServer{
+		logger:     hclog.NewNullLogger(),
+		config:     config,
+		serverURL:  "https://issuer.example.com",
+		pathPrefix: normalizePathPrefix(config.PathPrefix),
+		sessions:   make(map[string]*AuthSession),
+		codes:      make(map[string]*AuthCode),
+		tokens:     make(map[string]*AccessToken),
+	}
+	if err := server.setupJWTKeys(); err != nil {
+		t.Fatalf("Failed to setup JWT keys: %v", err)
+	}
+	if err := server.CacheDiscoveryDocument(); err != nil {
+		t.Fatalf("Failed to cache discovery document: %v", err)
+	}
+
+	var discovery map[string]interface{}
+	if err := json.Unmarshal(server.cachedDiscovery, &discovery); err != nil {
+		t.Fatalf("Failed to parse discovery document: %v", err)
+	}
+	if discovery["issuer"] != "https://issuer.example.com/custom-oidc" {
+		t.Errorf("Expected issuer 'https://issuer.example.com/custom-oidc', got %q", discovery["issuer"])
+	}
+	if discovery["authorization_endpoint"] != "https://issuer.example.com/custom-oidc/authorize" {
+		t.Errorf("Unexpected authorization_endpoint %q", discovery["authorization_endpoint"])
 	}
 }

--- a/external/plugins/oidc-server/plugin.go
+++ b/external/plugins/oidc-server/plugin.go
@@ -108,8 +108,9 @@ func (o *OIDCServer) Configure(cfg shared.ExternalConfig) (shared.PluginCapabili
 		o.config = getDefaultConfig()
 	}
 
-	// Store the path prefix for use in routing and URLs
-	o.pathPrefix = o.config.PathPrefix
+	// Store the path prefix for use in routing and URLs, normalised so every
+	// issuer/endpoint concatenation and route match is well-formed
+	o.pathPrefix = normalizePathPrefix(o.config.PathPrefix)
 
 	// Setup JWT signing keys based on algorithm
 	if err := o.setupJWTKeys(); err != nil {

--- a/external/plugins/oidc-server/plugin_test.go
+++ b/external/plugins/oidc-server/plugin_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/hashicorp/go-hclog"
 	"github.com/imposter-project/imposter-go/external/shared"
 )
@@ -600,4 +601,96 @@ func TestOIDCServer_CacheDiscoveryDocument_IssuerIncludesPathPrefix(t *testing.T
 			t.Errorf("Expected issuer %q, got %q", expectedIssuer, discovery["issuer"])
 		}
 	})
+}
+
+// TestOIDCServer_IssuerConsistency_AcrossComponents locks the three issuer
+// surfaces together so they can never silently drift apart again:
+//  1. the discovery document's "issuer" (plugin.go)
+//  2. the "iss" claim minted into ID tokens (token.go)
+//  3. the issuer the RP-initiated logout flow validates against (logout.go)
+//
+// The original bug (see TestOIDCServer_CacheDiscoveryDocument_IssuerIncludesPathPrefix)
+// slipped past every existing test because each surface independently used the
+// same wrong value, so they stayed internally consistent with one another while
+// collectively disagreeing with the URL clients actually use. Asserting each
+// value against a hardcoded literal in isolation would not have caught it. This
+// test instead asserts the relationships between the surfaces, under a
+// non-default path prefix, so changing any single one of them breaks it.
+func TestOIDCServer_IssuerConsistency_AcrossComponents(t *testing.T) {
+	config := &OIDCConfig{
+		PathPrefix: "/custom-oidc",
+		Users: []User{
+			{Username: "alice", Password: "password", Claims: map[string]string{"sub": "alice"}},
+		},
+		Clients: []Client{
+			{
+				ClientID:               "test-client",
+				ClientSecret:           "test-secret",
+				RedirectURIs:           []string{"https://issuer.example.com/callback"},
+				PostLogoutRedirectURIs: []string{"https://issuer.example.com/logged-out"},
+			},
+		},
+		JWTConfig: &JWTConfig{Algorithm: "RS256"},
+	}
+
+	server := &OIDCServer{
+		logger:     hclog.NewNullLogger(),
+		config:     config,
+		serverURL:  "https://issuer.example.com",
+		pathPrefix: config.PathPrefix,
+		sessions:   make(map[string]*AuthSession),
+		codes:      make(map[string]*AuthCode),
+		tokens:     make(map[string]*AccessToken),
+	}
+	if err := server.setupJWTKeys(); err != nil {
+		t.Fatalf("Failed to setup JWT keys: %v", err)
+	}
+	if err := server.CacheDiscoveryDocument(); err != nil {
+		t.Fatalf("Failed to cache discovery document: %v", err)
+	}
+
+	// 1. Issuer advertised by the discovery document.
+	var discovery map[string]interface{}
+	if err := json.Unmarshal(server.cachedDiscovery, &discovery); err != nil {
+		t.Fatalf("Failed to parse discovery document: %v", err)
+	}
+	discoveryIssuer, _ := discovery["issuer"].(string)
+
+	// It must include the configured path prefix — the location the discovery
+	// document is actually served from.
+	wantIssuer := "https://issuer.example.com/custom-oidc"
+	if discoveryIssuer != wantIssuer {
+		t.Errorf("discovery issuer = %q, want %q", discoveryIssuer, wantIssuer)
+	}
+
+	// 2. The iss claim minted into an ID token must equal the discovery issuer.
+	user := config.Users[0]
+	idToken, err := server.generateIDToken(&user, "test-client", "nonce-123", []string{"openid"}, time.Now(), 3600)
+	if err != nil {
+		t.Fatalf("Failed to generate ID token: %v", err)
+	}
+	parsed, err := jwt.Parse(idToken, func(token *jwt.Token) (interface{}, error) {
+		return server.publicKey, nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to parse ID token: %v", err)
+	}
+	tokenIss, _ := parsed.Claims.(jwt.MapClaims)["iss"].(string)
+	if tokenIss != discoveryIssuer {
+		t.Errorf("ID token iss = %q, but discovery issuer = %q; they must be identical", tokenIss, discoveryIssuer)
+	}
+
+	// 3. The RP-initiated logout flow must accept a token this same server minted.
+	//    A stale issuer check here would reject genuine tokens with an "issuer
+	//    mismatch" error.
+	clientID, sub, err := server.parseIDTokenHint(idToken)
+	if err != nil {
+		t.Fatalf("logout rejected a token minted by this server: %v", err)
+	}
+	if clientID != "test-client" {
+		t.Errorf("parseIDTokenHint clientID = %q, want %q", clientID, "test-client")
+	}
+	if sub != "alice" {
+		t.Errorf("parseIDTokenHint sub = %q, want %q", sub, "alice")
+	}
 }


### PR DESCRIPTION
Follow-up hardening to the OIDC issuer fix (#86): a cross-component regression test and normalisation of the configured path prefix.

## Summary

- Add a cross-component regression test asserting that the discovery document's `issuer`, the ID token `iss` claim, and the RP-initiated logout issuer check all agree — exercised under a non-default path prefix. The original issuer bug hid from every existing test because each surface independently used the same wrong value, staying internally consistent while collectively disagreeing with the URL clients actually use; asserting the relationships between the surfaces (rather than each one in isolation) closes that gap.
- Normalise the configured `path_prefix` to a canonical form: a single leading slash with no trailing slash. Previously the value was used verbatim, so `oidc` produced a malformed issuer (`https://hostoidc`) and broke request routing, while `/oidc/` produced double slashes in endpoint URLs.
- Empty or slash-only prefixes still fall back to the default `/oidc`, preserving existing behaviour.
- Add unit tests for the normalisation helper and an end-to-end check that a messy YAML `path_prefix` yields a well-formed discovery document.

## Implementation details

- Normalisation is applied at two choke points — when loading config (so the parsed and validated config is already canonical) and when configuring the server (so a server built from the default config, or any future config source, is guarded too). The helper is idempotent, so applying it in both places is harmless.
- Falling back to `/oidc` for empty or slash-only input is deliberate: serving the endpoints at the server root would be a behavioural change that routing does not currently support, so degenerate input keeps today's default rather than silently relocating the endpoints.