### PR TITLE
ci: mint plugin-repo token via github app instead of pat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,17 @@ jobs:
       id: version
       run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
+    # Mint a short-lived installation token scoped to the plugins repo, in place
+    # of a long-lived PAT.
+    - name: Generate token for imposter-go-plugins repo
+      id: plugin-repo-token
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ secrets.PLUGIN_RELEASE_APP_CLIENT_ID }}
+        private-key: ${{ secrets.PLUGIN_RELEASE_APP_PRIVATE_KEY }}
+        owner: imposter-project
+        repositories: imposter-go-plugins
+
     - name: Create draft release in imposter-go-plugins repo
       id: create_release
       run: |
@@ -158,7 +169,7 @@ jobs:
           --notes "External plugins for imposter-go ${{ steps.version.outputs.VERSION }}" \
           --draft
       env:
-        GITHUB_TOKEN: ${{ secrets.PLUGIN_REPO_TOKEN }}
+        GITHUB_TOKEN: ${{ steps.plugin-repo-token.outputs.token }}
 
     - name: Build plugins for multiple platforms
       run: ./scripts/build-plugins.sh ${{ steps.version.outputs.VERSION }} dist
@@ -173,7 +184,7 @@ jobs:
           fi
         done
       env:
-        GITHUB_TOKEN: ${{ secrets.PLUGIN_REPO_TOKEN }}
+        GITHUB_TOKEN: ${{ steps.plugin-repo-token.outputs.token }}
 
     - name: Publish release
       run: |
@@ -181,7 +192,7 @@ jobs:
           --repo imposter-project/imposter-go-plugins \
           --draft=false
       env:
-        GITHUB_TOKEN: ${{ secrets.PLUGIN_REPO_TOKEN }}
+        GITHUB_TOKEN: ${{ steps.plugin-repo-token.outputs.token }}
 
   docker-build:
     needs: build


### PR DESCRIPTION
## Summary
Replaces the long-lived `PLUGIN_REPO_TOKEN` PAT used by the `publish-plugins` release job with a short-lived GitHub App installation token, minted per run and scoped to `imposter-project/imposter-go-plugins`. The expired PAT caused the `v5.19.1` and `v5.19.2` release jobs to fail with `HTTP 401: Bad credentials`.

## Key changes
- Add an `actions/create-github-app-token` step scoped to the plugins repo, authenticating with the App Client ID (`Iv23liDOAv1QL15McL5V`) and private key.
- Point the three `gh release` steps (create draft, upload assets, publish) at the minted token instead of `secrets.PLUGIN_REPO_TOKEN`.

## Prerequisites (in place)
- App has Contents: Read & write on `imposter-go-plugins` and is installed on the repo.
- Repo secret `PLUGIN_RELEASE_APP_PRIVATE_KEY` holds the App private key.

The old `PLUGIN_REPO_TOKEN` (and the unused client secret) can be removed once this merges.