### PR TITLE
fix: replace startup panics with clean error messages

### DIFF
--- a/cmd/imposter/main.go
+++ b/cmd/imposter/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/imposter-project/imposter-go/internal/adapter/httpserver"
 	"github.com/imposter-project/imposter-go/internal/scheduler"
 	"github.com/imposter-project/imposter-go/internal/version"
+	"github.com/imposter-project/imposter-go/pkg/logger"
 )
 
 func main() {
@@ -38,7 +39,14 @@ func main() {
 	} else {
 		runtimeAdapter = httpserver.NewAdapter()
 	}
-	runtimeAdapter.Start()
+	if err := runtimeAdapter.Start(); err != nil {
+		// Report the failure concisely and exit non-zero, rather than
+		// letting a panic dump a stack trace for what is usually a
+		// configuration problem.
+		cleanup()
+		logger.Errorf("%v", err)
+		os.Exit(1)
+	}
 	cleanup()
 }
 

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -2,6 +2,8 @@ package adapter
 
 // Adapter represents a runtime adapter for the application
 type Adapter interface {
-	// Start begins the adapter's runtime execution
-	Start()
+	// Start begins the adapter's runtime execution. It returns an error if
+	// startup fails (for example, invalid configuration) so the caller can
+	// report it cleanly and exit with a non-zero status.
+	Start() error
 }

--- a/internal/adapter/awslambda/awslambda.go
+++ b/internal/adapter/awslambda/awslambda.go
@@ -29,8 +29,9 @@ func NewAdapter() adapter.Adapter {
 }
 
 // Start begins the Lambda runtime
-func (a *LambdaAdapter) Start() {
+func (a *LambdaAdapter) Start() error {
 	lambda.Start(HandleLambdaRequest)
+	return nil
 }
 
 var (
@@ -55,8 +56,15 @@ func init() {
 		os.Setenv("IMPOSTER_CONFIG_DIR", "/var/task/config")
 	}
 
-	// Load configuration once during cold start
-	imposterConfig, plugins = adapter.InitialiseImposter("")
+	// Load configuration once during cold start. A failure here is fatal:
+	// panicking is the AWS convention for signalling a failed init phase, and
+	// the error now carries a concise, user-facing message.
+	var err error
+	imposterConfig, plugins, err = adapter.InitialiseImposter("")
+	if err != nil {
+		logger.Errorf("failed to initialise imposter: %v", err)
+		panic(err)
+	}
 
 	// Schedules and websocket connections require a long-lived process, which
 	// the Lambda execution model does not provide.

--- a/internal/adapter/common.go
+++ b/internal/adapter/common.go
@@ -13,43 +13,52 @@ import (
 	"github.com/imposter-project/imposter-go/plugin"
 )
 
-// InitialiseImposter performs common initialisation tasks for all adapters
-func InitialiseImposter(configDirArg string) (*config.ImposterConfig, []plugin.Plugin) {
+// InitialiseImposter performs common initialisation tasks for all adapters.
+// It returns an error rather than panicking for user-facing problems (such as
+// missing or invalid configuration) so callers can present a concise message
+// and exit with a non-zero status instead of dumping a stack trace.
+func InitialiseImposter(configDirArg string) (*config.ImposterConfig, []plugin.Plugin, error) {
 	logger.Infof("starting imposter-go %s...", version.Version)
 
 	imposterConfig := config.LoadImposterConfig()
-	configDirs := getConfigDirs(configDirArg)
+	configDirs, err := getConfigDirs(configDirArg)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	store.InitStoreProvider()
 
 	var configs []config.Config
 	for _, configDir := range configDirs {
-		if info, err := os.Stat(configDir); os.IsNotExist(err) || !info.IsDir() {
-			panic(fmt.Errorf("specified config dir '%s' is not a valid directory", configDir))
+		if info, err := os.Stat(configDir); err != nil || !info.IsDir() {
+			return nil, nil, fmt.Errorf("specified config dir '%s' is not a valid directory", configDir)
 		}
 
-		cfgs := config.LoadConfig(configDir, imposterConfig)
-		store.PreloadStores(configDir, cfgs)
+		cfgs, err := config.LoadConfig(configDir, imposterConfig)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to load configuration from '%s': %w", configDir, err)
+		}
+		if err := store.PreloadStores(configDir, cfgs); err != nil {
+			return nil, nil, err
+		}
 
 		configs = append(configs, cfgs...)
 	}
 
-	// Exit if no configuration files were found
+	// Fail if no configuration files were found
 	if len(configs) == 0 {
-		logger.Errorf("no configuration files found in specified directories: %v", configDirs)
-		os.Exit(1)
-	} else {
-		logger.Tracef("%d configs discovered", len(configs))
+		return nil, nil, fmt.Errorf("no configuration files found in specified directories: %v", configDirs)
 	}
+	logger.Tracef("%d configs discovered", len(configs))
 
 	externalPlugins, err := external.StartExternalPlugins(imposterConfig, configs)
 	if err != nil {
-		panic(fmt.Errorf("error starting external plugins: %w", err))
+		return nil, nil, fmt.Errorf("error starting external plugins: %w", err)
 	}
 
 	plugins, err := plugin.LoadPlugins(configs, imposterConfig, externalPlugins)
 	if err != nil {
-		panic(fmt.Errorf("error loading plugins: %w", err))
+		return nil, nil, fmt.Errorf("error loading plugins: %w", err)
 	}
 
 	// Pre-calculate resource IDs for all loaded configurations.
@@ -59,19 +68,19 @@ func InitialiseImposter(configDirArg string) (*config.ImposterConfig, []plugin.P
 		config.PreCalculateResourceID(plg.GetConfig())
 	}
 
-	return imposterConfig, plugins
+	return imposterConfig, plugins, nil
 }
 
-func getConfigDirs(configDirArg string) []string {
+func getConfigDirs(configDirArg string) ([]string, error) {
 	var configDirRaw string
 	if configDirArg != "" {
 		configDirRaw = configDirArg
 	} else {
 		configDirRaw = os.Getenv("IMPOSTER_CONFIG_DIR")
 		if configDirRaw == "" {
-			panic("Config directory path must be provided either as an argument or via IMPOSTER_CONFIG_DIR environment variable")
+			return nil, fmt.Errorf("config directory path must be provided either as an argument or via the IMPOSTER_CONFIG_DIR environment variable")
 		}
 	}
 	configDirs := strings.Split(configDirRaw, ",")
-	return configDirs
+	return configDirs, nil
 }

--- a/internal/adapter/common_test.go
+++ b/internal/adapter/common_test.go
@@ -1,10 +1,8 @@
 package adapter
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/imposter-project/imposter-go/internal/config"
@@ -40,12 +38,12 @@ system:
 	require.NoError(t, err)
 
 	tests := []struct {
-		name          string
-		configDirArg  string
-		envConfigDir  string
-		envPort       string
-		wantPanic     bool
-		panicContains string
+		name         string
+		configDirArg string
+		envConfigDir string
+		envPort      string
+		wantErr      bool
+		errContains  string
 	}{
 		{
 			name:         "config dir from argument",
@@ -58,15 +56,15 @@ system:
 			envPort:      "9090",
 		},
 		{
-			name:          "missing config dir",
-			wantPanic:     true,
-			panicContains: "Config directory path must be provided either as an argument or via IMPOSTER_CONFIG_DIR environment variable",
+			name:        "missing config dir",
+			wantErr:     true,
+			errContains: "config directory path must be provided either as an argument or via the IMPOSTER_CONFIG_DIR environment variable",
 		},
 		{
-			name:          "invalid config dir",
-			configDirArg:  "/nonexistent/path",
-			wantPanic:     true,
-			panicContains: "specified config dir '/nonexistent/path' is not a valid directory",
+			name:         "invalid config dir",
+			configDirArg: "/nonexistent/path",
+			wantErr:      true,
+			errContains:  "specified config dir '/nonexistent/path' is not a valid directory",
 		},
 		{
 			name:         "default port",
@@ -88,15 +86,16 @@ system:
 				t.Setenv("IMPOSTER_PORT", "")
 			}
 
-			if tt.wantPanic {
-				assertPanicContains(t, tt.panicContains, func() {
-					InitialiseImposter(tt.configDirArg)
-				})
+			if tt.wantErr {
+				_, _, err := InitialiseImposter(tt.configDirArg)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
 				return
 			}
 
 			// Run initialisation
-			imposterConfig, plugins := InitialiseImposter(tt.configDirArg)
+			imposterConfig, plugins, err := InitialiseImposter(tt.configDirArg)
+			require.NoError(t, err)
 			assert.NotEmpty(t, plugins)
 
 			configs := []*config.Config{}
@@ -160,7 +159,8 @@ system:
 	require.NoError(t, err)
 
 	// Run initialisation
-	_, _ = InitialiseImposter(tmpDir)
+	_, _, err = InitialiseImposter(tmpDir)
+	require.NoError(t, err)
 
 	// Verify store initialisation
 	// Note: Since store is a global singleton, we can verify its state here
@@ -192,8 +192,9 @@ resources:
 	err := os.WriteFile(filepath.Join(tmpDir, "invalid-config.yml"), invalidConfig, 0644)
 	require.NoError(t, err)
 
-	// Run initialisation - it should not panic on invalid config
-	imposterConfig, plugins := InitialiseImposter(tmpDir)
+	// Run initialisation - it should not fail on invalid config
+	imposterConfig, plugins, err := InitialiseImposter(tmpDir)
+	require.NoError(t, err)
 	assert.NotEmpty(t, plugins)
 
 	configs := []*config.Config{}
@@ -209,31 +210,4 @@ resources:
 	if len(configs) > 0 {
 		assert.Equal(t, "rest", configs[0].Plugin)
 	}
-}
-
-// assertPanicContains checks that the function panics and the panic message contains the expected text
-func assertPanicContains(t *testing.T, expectedText string, f func()) {
-	t.Helper()
-	defer func() {
-		r := recover()
-		if r == nil {
-			t.Errorf("Expected panic, but function did not panic")
-			return
-		}
-
-		var actualMessage string
-		switch v := r.(type) {
-		case string:
-			actualMessage = v
-		case error:
-			actualMessage = v.Error()
-		default:
-			actualMessage = fmt.Sprintf("%v", v)
-		}
-
-		if !strings.Contains(actualMessage, expectedText) {
-			t.Errorf("Expected panic message to contain %q, but got %q", expectedText, actualMessage)
-		}
-	}()
-	f()
 }

--- a/internal/adapter/httpserver/httpserver.go
+++ b/internal/adapter/httpserver/httpserver.go
@@ -2,6 +2,7 @@ package httpserver
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	"os"
 	"time"
@@ -26,14 +27,17 @@ func NewAdapter() adapter.Adapter {
 }
 
 // Start begins the HTTP server runtime
-func (a *HTTPAdapter) Start() {
+func (a *HTTPAdapter) Start() error {
 	startTime := time.Now()
 	var configDirArg string
 	if len(os.Args) >= 2 {
 		configDirArg = os.Args[1]
 	}
 
-	imposterConfig, plugins := adapter.InitialiseImposter(configDirArg)
+	imposterConfig, plugins, err := adapter.InitialiseImposter(configDirArg)
+	if err != nil {
+		return err
+	}
 
 	// Start engine-lifetime scheduled jobs declared in the loaded configs
 	var configs []*config.Config
@@ -45,7 +49,7 @@ func (a *HTTPAdapter) Start() {
 	// Initialise and start the server with multiple configs
 	srv := newServer(imposterConfig, plugins)
 	logger.Infof("startup completed in %v", time.Since(startTime))
-	srv.start(imposterConfig)
+	return srv.start(imposterConfig)
 }
 
 // httpServer represents the HTTP server configuration.
@@ -66,7 +70,7 @@ func newServer(imposterConfig *config.ImposterConfig, plugins []plugin.Plugin) *
 // When TLS is configured, the server uses h2 (HTTP/2 over TLS), or HTTPS/1.1
 // when HTTP/2 is disabled. Otherwise it uses h2c (HTTP/2 cleartext), or plain
 // HTTP/1.1 when HTTP/2 is disabled.
-func (s *httpServer) start(imposterConfig *config.ImposterConfig) {
+func (s *httpServer) start(imposterConfig *config.ImposterConfig) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		handler.HandleRequest(imposterConfig, w, r, s.Plugins)
@@ -85,7 +89,7 @@ func (s *httpServer) start(imposterConfig *config.ImposterConfig) {
 			logger.Infof("server is listening on %s (https/1.1)...", s.Addr)
 		}
 		if err := server.ListenAndServeTLS(imposterConfig.TLSCertFile, imposterConfig.TLSKeyFile); err != nil {
-			logger.Errorf("error starting TLS server: %v", err)
+			return fmt.Errorf("error starting TLS server: %w", err)
 		}
 	} else {
 		var httpHandler http.Handler = mux
@@ -101,7 +105,8 @@ func (s *httpServer) start(imposterConfig *config.ImposterConfig) {
 			Handler: httpHandler,
 		}
 		if err := server.ListenAndServe(); err != nil {
-			logger.Errorf("error starting server: %v", err)
+			return fmt.Errorf("error starting server: %w", err)
 		}
 	}
+	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,7 +76,7 @@ func LoadImposterConfig() *ImposterConfig {
 }
 
 // LoadConfig loads all config files in the specified directory
-func LoadConfig(configDir string, imposterConfig *ImposterConfig) []Config {
+func LoadConfig(configDir string, imposterConfig *ImposterConfig) ([]Config, error) {
 	logger.Debugf("loading config files from %s", configDir)
 	var configs []Config
 
@@ -194,10 +194,10 @@ func LoadConfig(configDir string, imposterConfig *ImposterConfig) []Config {
 		return nil
 	})
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return coalesceWebSocketConfigs(configs)
+	return coalesceWebSocketConfigs(configs), nil
 }
 
 // coalesceWebSocketConfigs merges every 'websocket' config into a single

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -41,7 +41,8 @@ resources:
 	require.NoError(t, err)
 
 	// Load the config
-	configs := LoadConfig(tempDir, &ImposterConfig{})
+	configs, err := LoadConfig(tempDir, &ImposterConfig{})
+	require.NoError(t, err)
 	require.Len(t, configs, 1)
 
 	cfg := configs[0]
@@ -113,7 +114,8 @@ resources:
 	require.NoError(t, err)
 
 	// Load the config
-	configs := LoadConfig(tempDir, imposterConfig)
+	configs, err := LoadConfig(tempDir, imposterConfig)
+	require.NoError(t, err)
 	require.Len(t, configs, 1)
 
 	cfg := configs[0]
@@ -207,7 +209,8 @@ resources:
 	require.NoError(t, err)
 
 	// Load the config
-	configs := LoadConfig(tempDir, imposterConfig)
+	configs, err := LoadConfig(tempDir, imposterConfig)
+	require.NoError(t, err)
 	require.Len(t, configs, 1)
 
 	cfg := configs[0]
@@ -239,7 +242,8 @@ resources:
 	err := os.WriteFile(filepath.Join(tempDir, "test-config.yaml"), []byte(configContent), 0644)
 	require.NoError(t, err)
 
-	configs := LoadConfig(tempDir, imposterConfig)
+	configs, err := LoadConfig(tempDir, imposterConfig)
+	require.NoError(t, err)
 	require.Len(t, configs, 1)
 
 	cfg := configs[0]
@@ -268,7 +272,8 @@ resources:
 	err := os.WriteFile(filepath.Join(tempDir, "test-config.yaml"), []byte(configContent), 0644)
 	require.NoError(t, err)
 
-	configs := LoadConfig(tempDir, imposterConfig)
+	configs, err := LoadConfig(tempDir, imposterConfig)
+	require.NoError(t, err)
 	require.Len(t, configs, 1)
 
 	// Defined var is substituted; undefined reference is left intact
@@ -328,7 +333,8 @@ system:
 	require.NoError(t, err)
 
 	// Load the configs
-	configs := LoadConfig(tempDir, imposterConfig)
+	configs, err := LoadConfig(tempDir, imposterConfig)
+	require.NoError(t, err)
 	require.Len(t, configs, 2)
 
 	// Check root config
@@ -400,7 +406,8 @@ resources:
 	require.NoError(t, err)
 
 	// Load the config
-	configs := LoadConfig(tempDir, imposterConfig)
+	configs, err := LoadConfig(tempDir, imposterConfig)
+	require.NoError(t, err)
 	require.Len(t, configs, 1)
 
 	cfg := configs[0]
@@ -453,7 +460,8 @@ resources:
 	err := os.WriteFile(filepath.Join(tempDir, "test-config.yaml"), []byte(configContent), 0644)
 	require.NoError(t, err)
 
-	configs := LoadConfig(tempDir, imposterConfig)
+	configs, err := LoadConfig(tempDir, imposterConfig)
+	require.NoError(t, err)
 	require.Len(t, configs, 1)
 
 	cfg := configs[0]
@@ -507,7 +515,8 @@ resources:
 	require.NoError(t, err)
 
 	// Load the config
-	configs := LoadConfig(tempDir, imposterConfig)
+	configs, err := LoadConfig(tempDir, imposterConfig)
+	require.NoError(t, err)
 	require.Len(t, configs, 1)
 
 	cfg := configs[0]
@@ -625,7 +634,8 @@ func TestLoadConfig_WithRequestBody(t *testing.T) {
 	imposterConfig := &ImposterConfig{}
 
 	// Load the config from testdata
-	configs := LoadConfig("testdata", imposterConfig)
+	configs, err := LoadConfig("testdata", imposterConfig)
+	require.NoError(t, err)
 	require.Len(t, configs, 1)
 
 	cfg := configs[0]
@@ -709,7 +719,8 @@ resources:
 	require.NoError(t, err)
 
 	// Load the config
-	configs := LoadConfig(tempDir, imposterConfig)
+	configs, err := LoadConfig(tempDir, imposterConfig)
+	require.NoError(t, err)
 	require.Len(t, configs, 1)
 
 	cfg := configs[0]
@@ -779,7 +790,8 @@ validation:
 			require.NoError(t, err)
 
 			// Load the config
-			configs := LoadConfig(tempDir, imposterConfig)
+			configs, err := LoadConfig(tempDir, imposterConfig)
+			require.NoError(t, err)
 			require.Len(t, configs, 1)
 
 			cfg := configs[0]
@@ -835,7 +847,8 @@ resources:
 	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "sessions-config.yaml"), []byte(sessionsContent), 0644))
 
 	imposterConfig := &ImposterConfig{}
-	configs := LoadConfig(tempDir, imposterConfig)
+	configs, err := LoadConfig(tempDir, imposterConfig)
+	require.NoError(t, err)
 
 	// The two websocket files must collapse into a single config whose resources
 	// are the union of both files.
@@ -867,7 +880,8 @@ resources:
 	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "b-config.yaml"), []byte(restB), 0644))
 
 	imposterConfig := &ImposterConfig{}
-	configs := LoadConfig(tempDir, imposterConfig)
+	configs, err := LoadConfig(tempDir, imposterConfig)
+	require.NoError(t, err)
 
 	rest := 0
 	for _, c := range configs {

--- a/internal/config/security_test.go
+++ b/internal/config/security_test.go
@@ -228,7 +228,8 @@ resources:
 	require.NoError(t, err)
 
 	// Load the config
-	configs := LoadConfig(tempDir, imposterConfig)
+	configs, err := LoadConfig(tempDir, imposterConfig)
+	require.NoError(t, err)
 	require.Len(t, configs, 1)
 
 	cfg := configs[0]

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -92,14 +92,14 @@ func GetStoreProvider() StoreProvider {
 	return storeProvider
 }
 
-func PreloadStores(configDir string, configs []config.Config) {
+func PreloadStores(configDir string, configs []config.Config) error {
 	for _, cfg := range configs {
 		if cfg.System != nil && cfg.System.Stores != nil {
 			for storeName, definition := range cfg.System.Stores {
 				if definition.PreloadFile != "" {
 					filePath, err := utils.ValidatePath(definition.PreloadFile, configDir)
 					if err != nil {
-						panic(fmt.Errorf("invalid preload file path: %s", definition.PreloadFile))
+						return fmt.Errorf("invalid preload file path: %s", definition.PreloadFile)
 					}
 					preloadFromFile(storeName, filePath)
 				}
@@ -109,6 +109,7 @@ func PreloadStores(configDir string, configs []config.Config) {
 			}
 		}
 	}
+	return nil
 }
 
 func preloadFromFile(storeName string, path string) {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -43,7 +43,9 @@ func TestPreloadStores(t *testing.T) {
 	storeProvider.InitStores()
 
 	// Test preloading
-	PreloadStores(tmpDir, configs)
+	if err := PreloadStores(tmpDir, configs); err != nil {
+		t.Fatal(err)
+	}
 
 	t.Run("PreloadedFileStore", func(t *testing.T) {
 		s := Open("fileStore", nil)

--- a/plugin/openapi/handler_test.go
+++ b/plugin/openapi/handler_test.go
@@ -335,7 +335,8 @@ Content-Type: image/jpeg
 
 			// Load config
 			imposterConfig := &config.ImposterConfig{}
-			configs := config.LoadConfig(tt.configDir, imposterConfig)
+			configs, err := config.LoadConfig(tt.configDir, imposterConfig)
+			require.NoError(t, err)
 			require.Len(t, configs, 1, "Expected one config")
 			cfg := &configs[0]
 

--- a/plugin/soap/handler.go
+++ b/plugin/soap/handler.go
@@ -23,7 +23,12 @@ type MessageBodyHolder struct {
 	EnvNamespace    string
 }
 
-// GetSOAPVersion returns the SOAP version based on the envelope namespace
+// GetSOAPVersion returns the SOAP version based on the envelope namespace.
+//
+// The envelope namespace is validated in parseBody before a MessageBodyHolder
+// is constructed, so a request-derived holder always carries a recognised
+// namespace. The default branch is therefore a defensive invariant guarding
+// against a programmatically constructed holder with an invalid namespace.
 func (b *MessageBodyHolder) GetSOAPVersion() SOAPVersion {
 	switch b.EnvNamespace {
 	case SOAP11EnvNamespace:
@@ -113,6 +118,17 @@ func (h *PluginHandler) parseBody(body []byte) (*MessageBodyHolder, error) {
 	bodyNode := xmlquery.FindOne(doc, "//*[local-name()='Body']/*[1]")
 	if bodyNode == nil {
 		return nil, fmt.Errorf("no SOAP body element found")
+	}
+
+	// Reject unrecognised envelope namespaces here so that downstream SOAP
+	// version detection never receives an unsupported envelope. This turns a
+	// malformed request into a proper SOAP Fault (see the caller) rather than
+	// a panic from GetSOAPVersion.
+	switch envNamespace {
+	case SOAP11EnvNamespace, SOAP12DraftEnvNamespace, SOAP12RecEnvNamespace:
+		// recognised SOAP envelope namespace
+	default:
+		return nil, fmt.Errorf("root element is not a SOAP envelope - namespace is %s", envNamespace)
 	}
 
 	return &MessageBodyHolder{

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -33,7 +33,8 @@ resources:
 	require.NoError(t, err)
 
 	imposterConfig := config.LoadImposterConfig()
-	configs := config.LoadConfig(tempDir, imposterConfig)
+	configs, err := config.LoadConfig(tempDir, imposterConfig)
+	require.NoError(t, err)
 	plugins, err := plugin.LoadPlugins(configs, imposterConfig, nil)
 	require.NoError(t, err)
 
@@ -75,7 +76,8 @@ resources:
 	require.NoError(t, err)
 
 	imposterConfig := config.LoadImposterConfig()
-	configs := config.LoadConfig(tempDir, imposterConfig)
+	configs, err := config.LoadConfig(tempDir, imposterConfig)
+	require.NoError(t, err)
 	plugins, err := plugin.LoadPlugins(configs, imposterConfig, nil)
 	require.NoError(t, err)
 

--- a/test/log_test.go
+++ b/test/log_test.go
@@ -40,7 +40,8 @@ resources:
 		ServerPort: "8080",
 		ServerUrl:  "http://localhost:8080",
 	}
-	configs := config.LoadConfig(tempDir, imposterConfig)
+	configs, err := config.LoadConfig(tempDir, imposterConfig)
+	require.NoError(t, err)
 	plugins, err := plugin.LoadPlugins(configs, imposterConfig, nil)
 	require.NoError(t, err)
 

--- a/test/passthrough_test.go
+++ b/test/passthrough_test.go
@@ -24,7 +24,8 @@ func startPassthroughServer(t *testing.T, configContent string) *httptest.Server
 	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "test-config.yaml"), []byte(configContent), 0644))
 
 	imposterConfig := config.LoadImposterConfig()
-	configs := config.LoadConfig(tempDir, imposterConfig)
+	configs, err := config.LoadConfig(tempDir, imposterConfig)
+	require.NoError(t, err)
 	plugins, err := plugin.LoadPlugins(configs, imposterConfig, nil)
 	require.NoError(t, err)
 
@@ -134,7 +135,8 @@ resources:
 	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "test-config.yaml"), []byte(cfg), 0644))
 
 	imposterConfig := config.LoadImposterConfig()
-	configs := config.LoadConfig(tempDir, imposterConfig)
-	_, err := plugin.LoadPlugins(configs, imposterConfig, nil)
+	configs, err := config.LoadConfig(tempDir, imposterConfig)
+	require.NoError(t, err)
+	_, err = plugin.LoadPlugins(configs, imposterConfig, nil)
 	require.Error(t, err)
 }

--- a/test/response_template_test.go
+++ b/test/response_template_test.go
@@ -37,7 +37,8 @@ resources:
 	require.NoError(t, err)
 
 	imposterConfig := config.LoadImposterConfig()
-	configs := config.LoadConfig(tempDir, imposterConfig)
+	configs, err := config.LoadConfig(tempDir, imposterConfig)
+	require.NoError(t, err)
 	plugins, err := plugin.LoadPlugins(configs, imposterConfig, nil)
 	require.NoError(t, err)
 
@@ -73,7 +74,8 @@ resources:
 	require.NoError(t, err)
 
 	imposterConfig := config.LoadImposterConfig()
-	configs := config.LoadConfig(tempDir, imposterConfig)
+	configs, err := config.LoadConfig(tempDir, imposterConfig)
+	require.NoError(t, err)
 	plugins, err := plugin.LoadPlugins(configs, imposterConfig, nil)
 	require.NoError(t, err)
 
@@ -109,7 +111,8 @@ resources:
 	require.NoError(t, err)
 
 	imposterConfig := config.LoadImposterConfig()
-	configs := config.LoadConfig(tempDir, imposterConfig)
+	configs, err := config.LoadConfig(tempDir, imposterConfig)
+	require.NoError(t, err)
 	plugins, err := plugin.LoadPlugins(configs, imposterConfig, nil)
 	require.NoError(t, err)
 
@@ -145,7 +148,8 @@ resources:
 	require.NoError(t, err)
 
 	imposterConfig := config.LoadImposterConfig()
-	configs := config.LoadConfig(tempDir, imposterConfig)
+	configs, err := config.LoadConfig(tempDir, imposterConfig)
+	require.NoError(t, err)
 	plugins, err := plugin.LoadPlugins(configs, imposterConfig, nil)
 	require.NoError(t, err)
 
@@ -181,7 +185,8 @@ resources:
 	require.NoError(t, err)
 
 	imposterConfig := config.LoadImposterConfig()
-	configs := config.LoadConfig(tempDir, imposterConfig)
+	configs, err := config.LoadConfig(tempDir, imposterConfig)
+	require.NoError(t, err)
 	plugins, err := plugin.LoadPlugins(configs, imposterConfig, nil)
 	require.NoError(t, err)
 
@@ -221,7 +226,8 @@ resources:
 	require.NoError(t, err)
 
 	imposterConfig := config.LoadImposterConfig()
-	configs := config.LoadConfig(tempDir, imposterConfig)
+	configs, err := config.LoadConfig(tempDir, imposterConfig)
+	require.NoError(t, err)
 	plugins, err := plugin.LoadPlugins(configs, imposterConfig, nil)
 	require.NoError(t, err)
 

--- a/test/scheduler_test.go
+++ b/test/scheduler_test.go
@@ -48,7 +48,8 @@ schedules:
 
 	store.InitStoreProvider()
 	imposterConfig := config.LoadImposterConfig()
-	configs := config.LoadConfig(tempDir, imposterConfig)
+	configs, err := config.LoadConfig(tempDir, imposterConfig)
+	require.NoError(t, err)
 	require.Len(t, configs, 1)
 
 	scheduler.Start([]*config.Config{&configs[0]}, imposterConfig)

--- a/test/websocket_test.go
+++ b/test/websocket_test.go
@@ -29,7 +29,8 @@ func startWebSocketServer(t *testing.T, configContent string) *httptest.Server {
 
 	store.InitStoreProvider()
 	imposterConfig := config.LoadImposterConfig()
-	configs := config.LoadConfig(tempDir, imposterConfig)
+	configs, err := config.LoadConfig(tempDir, imposterConfig)
+	require.NoError(t, err)
 	plugins, err := plugin.LoadPlugins(configs, imposterConfig, nil)
 	require.NoError(t, err)
 
@@ -213,7 +214,8 @@ resources:
 	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "rest-config.yaml"), []byte(restConfig), 0644))
 
 	imposterConfig := config.LoadImposterConfig()
-	configs := config.LoadConfig(tempDir, imposterConfig)
+	configs, err := config.LoadConfig(tempDir, imposterConfig)
+	require.NoError(t, err)
 	plugins, err := plugin.LoadPlugins(configs, imposterConfig, nil)
 	require.NoError(t, err)
 
@@ -366,7 +368,8 @@ resources:
 
 	store.InitStoreProvider()
 	imposterConfig := config.LoadImposterConfig()
-	configs := config.LoadConfig(tempDir, imposterConfig)
+	configs, err := config.LoadConfig(tempDir, imposterConfig)
+	require.NoError(t, err)
 	plugins, err := plugin.LoadPlugins(configs, imposterConfig, nil)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Startup-path failures now surface as concise error messages with a non-zero exit code, instead of dumping a goroutine stack trace that reads as a crash for what are ordinary configuration problems.

## Summary

- Return errors instead of panicking across the initialisation chain: `LoadConfig`, `PreloadStores`, `InitialiseImposter`, and `Adapter.Start()` now propagate failures rather than calling `panic()`.
- `main` reports the failure concisely at ERROR level, runs cleanup, and exits with status 1 — no stack trace. Covers missing/invalid config dir, malformed config, plugin-load failures, and invalid preload paths.
- The HTTP adapter now propagates listen failures, so a failed port bind exits non-zero instead of exiting 0.
- Hardened the config-dir check so a non-`NotExist` stat error (e.g. permission denied) reports "not a valid directory" instead of nil-dereferencing.
- Validate the SOAP envelope namespace in `parseBody`, so a malformed request yields a proper SOAP Fault (HTTP 400) rather than a panic from `GetSOAPVersion`.
- Updated tests to assert returned errors instead of panics.

## Implementation details

The exit decision is centralised in `main`: initialisation returns errors all the way up, and the single caller decides how to report and exit. This also fixes a latent case where a failed listen previously exited 0.

AWS Lambda keeps the panic-on-init-failure behaviour, which is the convention for signalling a failed init phase to the runtime, but now panics with the concise, wrapped message rather than deep inside the call stack.

Genuine programmer-invariant panics are intentionally retained: feature-flag registry misuse (fail-fast on a developer bug at init), the status endpoint's marshal of a fixed struct (cannot fail), and the goja `panic(vm.ToValue(...))` idiom (which is how a JavaScript exception is raised from native code, not a crash).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KHD9GDquMKNAhR5LM7cu8w)_