### PR TITLE
feat: merge split websocket configs onto one connection

### DIFF
--- a/internal/config/coalesce_test.go
+++ b/internal/config/coalesce_test.go
@@ -1,0 +1,187 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// findByBasePath returns the single config whose BasePath matches, failing the
+// test if there is not exactly one. BasePath is used purely as a label here.
+func findByBasePath(t *testing.T, configs []Config, basePath string) Config {
+	t.Helper()
+	var found []Config
+	for _, c := range configs {
+		if c.BasePath == basePath {
+			found = append(found, c)
+		}
+	}
+	require.Len(t, found, 1, "expected exactly one config labelled %q", basePath)
+	return found[0]
+}
+
+func TestCoalesceWebSocketConfigs_SingleConfigUnchanged(t *testing.T) {
+	in := []Config{
+		{Plugin: "websocket", BasePath: "ws", Resources: []Resource{{}, {}}},
+	}
+
+	out := coalesceWebSocketConfigs(in)
+
+	require.Len(t, out, 1)
+	require.Equal(t, "websocket", out[0].Plugin)
+	require.Len(t, out[0].Resources, 2, "a lone websocket config must pass through untouched")
+}
+
+func TestCoalesceWebSocketConfigs_NoWebSocketConfigs(t *testing.T) {
+	in := []Config{
+		{Plugin: "rest", BasePath: "a"},
+		{Plugin: "soap", BasePath: "b"},
+	}
+
+	out := coalesceWebSocketConfigs(in)
+
+	require.Len(t, out, 2, "configs without any websocket plugin are returned as-is")
+	require.Equal(t, "a", out[0].BasePath)
+	require.Equal(t, "b", out[1].BasePath)
+}
+
+func TestCoalesceWebSocketConfigs_MergesResourcesAcrossFiles(t *testing.T) {
+	in := []Config{
+		{Plugin: "websocket", BasePath: "ws1", Resources: []Resource{{}, {}}},
+		{Plugin: "websocket", BasePath: "ws2", Resources: []Resource{{}}},
+		{Plugin: "websocket", BasePath: "ws3", Resources: []Resource{{}, {}, {}}},
+	}
+
+	out := coalesceWebSocketConfigs(in)
+
+	require.Len(t, out, 1, "all websocket configs collapse into one")
+	require.Equal(t, "ws1", out[0].BasePath, "the merged config keeps the first one's position/identity")
+	require.Len(t, out[0].Resources, 6, "resources are the union of every websocket file")
+}
+
+func TestCoalesceWebSocketConfigs_PreservesOrderAmongOtherPlugins(t *testing.T) {
+	in := []Config{
+		{Plugin: "rest", BasePath: "restA"},
+		{Plugin: "websocket", BasePath: "ws1", Resources: []Resource{{}}},
+		{Plugin: "rest", BasePath: "restB"},
+		{Plugin: "websocket", BasePath: "ws2", Resources: []Resource{{}, {}}},
+	}
+
+	out := coalesceWebSocketConfigs(in)
+
+	// rest configs are untouched and keep their relative order; the merged
+	// websocket config stays where the first websocket config was (index 1).
+	require.Len(t, out, 3)
+	require.Equal(t, "restA", out[0].BasePath)
+	require.Equal(t, "websocket", out[1].Plugin)
+	require.Equal(t, "ws1", out[1].BasePath)
+	require.Len(t, out[1].Resources, 3)
+	require.Equal(t, "restB", out[2].BasePath)
+}
+
+func TestCoalesceWebSocketConfigs_MergesInterceptorsAndSchedules(t *testing.T) {
+	in := []Config{
+		{
+			Plugin:       "websocket",
+			BasePath:     "ws1",
+			Interceptors: []Interceptor{{}},
+			Schedules:    []Schedule{{}},
+		},
+		{
+			Plugin:       "websocket",
+			BasePath:     "ws2",
+			Interceptors: []Interceptor{{}, {}},
+			Schedules:    []Schedule{{}, {}, {}},
+		},
+	}
+
+	out := coalesceWebSocketConfigs(in)
+
+	require.Len(t, out, 1)
+	require.Len(t, out[0].Interceptors, 3, "interceptors from every websocket file are merged")
+	require.Len(t, out[0].Schedules, 4, "schedules from every websocket file are merged")
+}
+
+func TestCoalesceWebSocketConfigs_MergesSystemStoresFromEachFile(t *testing.T) {
+	in := []Config{
+		{
+			Plugin:   "websocket",
+			BasePath: "ws1",
+			System:   &System{Stores: map[string]StoreDefinition{"a": {PreloadFile: "a.json"}}},
+		},
+		{
+			Plugin:   "websocket",
+			BasePath: "ws2",
+			System:   &System{Stores: map[string]StoreDefinition{"b": {PreloadFile: "b.json"}}},
+		},
+	}
+
+	out := coalesceWebSocketConfigs(in)
+
+	require.Len(t, out, 1)
+	require.NotNil(t, out[0].System)
+	require.Len(t, out[0].System.Stores, 2, "each split file may declare its own store")
+	require.Equal(t, "a.json", out[0].System.Stores["a"].PreloadFile)
+	require.Equal(t, "b.json", out[0].System.Stores["b"].PreloadFile)
+}
+
+func TestMergeSystem_ExtraNilLeavesBaseUntouched(t *testing.T) {
+	base := &Config{System: &System{Stores: map[string]StoreDefinition{"a": {}}}}
+
+	mergeSystem(base, nil)
+
+	require.Len(t, base.System.Stores, 1, "a nil extra System is a no-op")
+}
+
+func TestMergeSystem_AdoptsExtraWhenBaseHasNone(t *testing.T) {
+	base := &Config{}
+	extra := &System{Stores: map[string]StoreDefinition{"a": {PreloadFile: "a.json"}}}
+
+	mergeSystem(base, extra)
+
+	require.Same(t, extra, base.System, "base with no System adopts extra directly")
+}
+
+func TestMergeSystem_MergesIntoNilMaps(t *testing.T) {
+	// base.System exists but its maps are nil, exercising the lazy-init branches.
+	base := &Config{System: &System{}}
+	extra := &System{
+		Stores:        map[string]StoreDefinition{"a": {PreloadFile: "a.json"}},
+		XMLNamespaces: map[string]string{"ns": "urn:example"},
+	}
+
+	mergeSystem(base, extra)
+
+	require.Equal(t, "a.json", base.System.Stores["a"].PreloadFile)
+	require.Equal(t, "urn:example", base.System.XMLNamespaces["ns"])
+}
+
+func TestMergeSystem_MergesStoresAndNamespaces(t *testing.T) {
+	base := &Config{System: &System{
+		Stores:        map[string]StoreDefinition{"a": {PreloadFile: "a.json"}},
+		XMLNamespaces: map[string]string{"ns1": "urn:one"},
+	}}
+	extra := &System{
+		Stores:        map[string]StoreDefinition{"b": {PreloadFile: "b.json"}},
+		XMLNamespaces: map[string]string{"ns2": "urn:two"},
+	}
+
+	mergeSystem(base, extra)
+
+	require.Len(t, base.System.Stores, 2)
+	require.Equal(t, "a.json", base.System.Stores["a"].PreloadFile)
+	require.Equal(t, "b.json", base.System.Stores["b"].PreloadFile)
+	require.Equal(t, "urn:one", base.System.XMLNamespaces["ns1"])
+	require.Equal(t, "urn:two", base.System.XMLNamespaces["ns2"])
+}
+
+func TestMergeSystem_ExtraOverwritesOnStoreNameClash(t *testing.T) {
+	base := &Config{System: &System{Stores: map[string]StoreDefinition{"shared": {PreloadFile: "base.json"}}}}
+	extra := &System{Stores: map[string]StoreDefinition{"shared": {PreloadFile: "extra.json"}}}
+
+	mergeSystem(base, extra)
+
+	require.Len(t, base.System.Stores, 1)
+	require.Equal(t, "extra.json", base.System.Stores["shared"].PreloadFile,
+		"on a store-name clash the later file wins")
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -197,7 +197,67 @@ func LoadConfig(configDir string, imposterConfig *ImposterConfig) []Config {
 		panic(err)
 	}
 
-	return configs
+	return coalesceWebSocketConfigs(configs)
+}
+
+// coalesceWebSocketConfigs merges every 'websocket' config into a single
+// config, preserving the position of the first one and leaving all other
+// plugins untouched.
+//
+// A websocket connection is multiplexed over one long-lived connection owned by
+// a single plugin instance: the first plugin whose path matches the upgrade
+// handles every subsequent message using only its own resources. Without this
+// merge, splitting websocket mocks across several '*-config.yaml' files would
+// silently drop all but the first file's resources (and its 'on: open'
+// schedule). Merging is safe because, by this point, the loader has already
+// rewritten each resource's referenced files relative to the shared root
+// ConfigDir, so resources from different files resolve correctly.
+func coalesceWebSocketConfigs(configs []Config) []Config {
+	firstIdx := -1
+	var result []Config
+	for i := range configs {
+		cfg := configs[i]
+		if cfg.Plugin != "websocket" {
+			result = append(result, cfg)
+			continue
+		}
+		if firstIdx == -1 {
+			firstIdx = len(result)
+			result = append(result, cfg)
+			continue
+		}
+		base := &result[firstIdx]
+		base.Resources = append(base.Resources, cfg.Resources...)
+		base.Interceptors = append(base.Interceptors, cfg.Interceptors...)
+		base.Schedules = append(base.Schedules, cfg.Schedules...)
+		mergeSystem(base, cfg.System)
+	}
+	return result
+}
+
+// mergeSystem folds the stores and XML namespaces of an additional config's
+// System block into the base config, so split websocket files may each declare
+// their own preloaded stores.
+func mergeSystem(base *Config, extra *System) {
+	if extra == nil {
+		return
+	}
+	if base.System == nil {
+		base.System = extra
+		return
+	}
+	for name, def := range extra.Stores {
+		if base.System.Stores == nil {
+			base.System.Stores = make(map[string]StoreDefinition)
+		}
+		base.System.Stores[name] = def
+	}
+	for prefix, uri := range extra.XMLNamespaces {
+		if base.System.XMLNamespaces == nil {
+			base.System.XMLNamespaces = make(map[string]string)
+		}
+		base.System.XMLNamespaces[prefix] = uri
+	}
 }
 
 // loadIgnorePaths loads ignore paths from .imposterignore file or uses default ignore paths

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -235,9 +235,18 @@ func coalesceWebSocketConfigs(configs []Config) []Config {
 	return result
 }
 
-// mergeSystem folds the stores and XML namespaces of an additional config's
-// System block into the base config, so split websocket files may each declare
-// their own preloaded stores.
+// mergeSystem folds an additional config's System block - its preloaded stores
+// and XML namespaces - into the base config.
+//
+// The System block is a general, server-wide feature, not websocket-specific:
+// store names share one global namespace, store.PreloadStores preloads the
+// stores of every loaded config at startup, and XML namespaces are read per
+// config for XPath matching (see pipeline.go and the soap handler). Those
+// consumers all iterate the config list returned by LoadConfig. Because
+// coalescing removes the other websocket configs from that list, their System
+// entries have to be carried onto the surviving config - otherwise their stores
+// would silently never preload and their namespaces would be missing from
+// XPath matchers on the merged connection.
 func mergeSystem(base *Config, extra *System) {
 	if extra == nil {
 		return

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -804,3 +804,76 @@ validation:
 		})
 	}
 }
+
+func TestLoadConfig_CoalescesWebSocketConfigs(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Two separate websocket config files, each on the same wildcard path.
+	openContent := `plugin: websocket
+resources:
+  - path: /*
+    on: open
+    response:
+      content: hello
+  - path: /*
+    requestBody:
+      jsonPath: $.method
+      value: ping
+    response:
+      content: pong`
+
+	sessionsContent := `plugin: websocket
+resources:
+  - path: /*
+    requestBody:
+      jsonPath: $.method
+      value: sessions.list
+    response:
+      content: sessions`
+
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "open-config.yaml"), []byte(openContent), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "sessions-config.yaml"), []byte(sessionsContent), 0644))
+
+	imposterConfig := &ImposterConfig{}
+	configs := LoadConfig(tempDir, imposterConfig)
+
+	// The two websocket files must collapse into a single config whose resources
+	// are the union of both files.
+	var wsConfigs []Config
+	for _, c := range configs {
+		if c.Plugin == "websocket" {
+			wsConfigs = append(wsConfigs, c)
+		}
+	}
+	require.Len(t, wsConfigs, 1, "expected websocket configs to be merged into one")
+	require.Len(t, wsConfigs[0].Resources, 3, "merged config should hold resources from both files")
+}
+
+func TestLoadConfig_LeavesOtherPluginsSeparate(t *testing.T) {
+	tempDir := t.TempDir()
+
+	restA := `plugin: rest
+resources:
+  - path: /a
+    response:
+      content: a`
+	restB := `plugin: rest
+resources:
+  - path: /b
+    response:
+      content: b`
+
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "a-config.yaml"), []byte(restA), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "b-config.yaml"), []byte(restB), 0644))
+
+	imposterConfig := &ImposterConfig{}
+	configs := LoadConfig(tempDir, imposterConfig)
+
+	rest := 0
+	for _, c := range configs {
+		if c.Plugin == "rest" {
+			rest++
+		}
+	}
+	require.Equal(t, 2, rest, "non-websocket plugins must not be merged")
+}

--- a/test/websocket_test.go
+++ b/test/websocket_test.go
@@ -318,3 +318,75 @@ resources:
 		conn.Close()
 	}
 }
+
+// TestWebSocket_SplitConfigsMergeOntoOneConnection proves that websocket
+// resources spread across several *-config.yaml files are all active on a
+// single multiplexed connection (the loader coalesces them into one handler).
+func TestWebSocket_SplitConfigsMergeOntoOneConnection(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// File 1: owns the handshake (on: open) and one method.
+	openConfig := `plugin: websocket
+resources:
+  - path: /*
+    on: open
+    response:
+      content: '{"event":"open"}'
+  - path: /*
+    requestBody:
+      allOf:
+        - jsonPath: $.method
+          value: agents.list
+    capture:
+      reqId:
+        requestBody:
+          jsonPath: $.id
+    response:
+      content: '{"id":"${stores.request.reqId}","payload":"agents"}'
+      template: true`
+
+	// File 2: a different method, in a separate file.
+	sessionsConfig := `plugin: websocket
+resources:
+  - path: /*
+    requestBody:
+      allOf:
+        - jsonPath: $.method
+          value: sessions.list
+    capture:
+      reqId:
+        requestBody:
+          jsonPath: $.id
+    response:
+      content: '{"id":"${stores.request.reqId}","payload":"sessions"}'
+      template: true`
+
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "open-config.yaml"), []byte(openConfig), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "sessions-config.yaml"), []byte(sessionsConfig), 0644))
+
+	store.InitStoreProvider()
+	imposterConfig := config.LoadImposterConfig()
+	configs := config.LoadConfig(tempDir, imposterConfig)
+	plugins, err := plugin.LoadPlugins(configs, imposterConfig, nil)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handler.HandleRequest(imposterConfig, w, r, plugins)
+	}))
+	t.Cleanup(server.Close)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(server, "/ws"), nil)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// on: open resource (file 1) fires.
+	require.JSONEq(t, `{"event":"open"}`, readTextMessage(t, conn))
+
+	// Method from file 1.
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"req","id":"1","method":"agents.list"}`)))
+	require.JSONEq(t, `{"id":"1","payload":"agents"}`, readTextMessage(t, conn))
+
+	// Method from file 2 - would be dead without coalescing.
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"req","id":"2","method":"sessions.list"}`)))
+	require.JSONEq(t, `{"id":"2","payload":"sessions"}`, readTextMessage(t, conn))
+}


### PR DESCRIPTION
Merge every `plugin: websocket` config into a single handler so a mock can be split across several `*-config.yaml` files.

## Summary
- Coalesce all websocket configs into one config at load time (`coalesceWebSocketConfigs` in `internal/config/config.go`), leaving other plugins untouched.
- Merge each split file's resources, interceptors, schedules and `system` stores/namespaces onto the first websocket config, preserving its position among other plugins.
- Add unit tests for the coalescing and system-merge branches, plus an integration test proving methods defined in separate files all respond on one connection.

## Implementation details
A websocket connection is multiplexed over one long-lived connection owned by a single plugin instance: the first plugin whose path matches the upgrade handles every subsequent message using only its own resources. Splitting a websocket mock across files therefore used to silently drop all but the first file's resources (and its `on: open` schedule).

Merging is safe at this point in loading because the loader has already rewritten each resource's referenced files relative to the shared root `ConfigDir`, so resources from different files resolve correctly. Non-websocket plugins (rest/openapi/soap) are deliberately left as separate instances, since they carry per-config settings (spec/WSDL files) that must not be combined.