### PR TITLE
fix: preserve query, body, headers and cookies in Lambda adapter

### DIFF
--- a/internal/adapter/awslambda/awslambda.go
+++ b/internal/adapter/awslambda/awslambda.go
@@ -80,74 +80,69 @@ func init() {
 	}
 }
 
-// lambdaEventType identifies which Lambda HTTP event shape a payload carries.
-type lambdaEventType int
+// lambdaHTTPEvent holds the fields of the supported Lambda HTTP event shapes
+// that the adapter consumes, so an incoming payload is JSON-decoded exactly
+// once regardless of its shape. API Gateway proxy (v1) carries a top-level
+// httpMethod; Function URL / API Gateway HTTP API (v2) carries
+// requestContext.http.method instead. AWS routing metadata not read by the
+// handlers (e.g. stageVariables, pathParameters, resource) is intentionally
+// omitted.
+type lambdaHTTPEvent struct {
+	// API Gateway proxy (v1)
+	HTTPMethod                      string              `json:"httpMethod"`
+	Path                            string              `json:"path"`
+	MultiValueHeaders               map[string][]string `json:"multiValueHeaders"`
+	QueryStringParameters           map[string]string   `json:"queryStringParameters"`
+	MultiValueQueryStringParameters map[string][]string `json:"multiValueQueryStringParameters"`
 
-const (
-	eventUnknown lambdaEventType = iota
-	eventAPIGatewayProxy
-	eventLambdaFunctionURL
-)
+	// Function URL / API Gateway HTTP API (v2)
+	RawPath        string   `json:"rawPath"`
+	RawQueryString string   `json:"rawQueryString"`
+	Cookies        []string `json:"cookies"`
+	RequestContext struct {
+		HTTP struct {
+			Method string `json:"method"`
+		} `json:"http"`
+	} `json:"requestContext"`
 
-// detectLambdaEventType inspects only the discriminating fields of the payload
-// so the full event is decoded once, into the correct type. API Gateway proxy
-// (v1) carries a top-level httpMethod; Function URL / API Gateway HTTP API (v2)
-// carries requestContext.http.method instead.
-func detectLambdaEventType(req json.RawMessage) lambdaEventType {
-	var probe struct {
-		HTTPMethod     string `json:"httpMethod"`
-		RequestContext struct {
-			HTTP struct {
-				Method string `json:"method"`
-			} `json:"http"`
-		} `json:"requestContext"`
-	}
-	if err := json.Unmarshal(req, &probe); err != nil {
-		return eventUnknown
-	}
-	switch {
-	case probe.HTTPMethod != "":
-		return eventAPIGatewayProxy
-	case probe.RequestContext.HTTP.Method != "":
-		return eventLambdaFunctionURL
-	default:
-		return eventUnknown
-	}
+	// Shared
+	Headers         map[string]string `json:"headers"`
+	Body            string            `json:"body"`
+	IsBase64Encoded bool              `json:"isBase64Encoded"`
 }
 
-// HandleLambdaRequest handles incoming Lambda requests and routes them to the appropriate handler.
+// HandleLambdaRequest handles incoming Lambda requests and routes them to the
+// appropriate handler. The payload is decoded once into a lambdaHTTPEvent and
+// the event shape is determined from its discriminating fields, so neither
+// shape is ever decoded twice.
 func HandleLambdaRequest(req json.RawMessage) (interface{}, error) {
-	switch detectLambdaEventType(req) {
-	case eventAPIGatewayProxy:
-		var apiGatewayReq events.APIGatewayProxyRequest
-		if err := json.Unmarshal(req, &apiGatewayReq); err != nil {
-			return events.APIGatewayProxyResponse{StatusCode: 400, Body: "Unsupported request type"}, nil
-		}
-		return handleAPIGatewayProxyRequest(apiGatewayReq, plugins)
-	case eventLambdaFunctionURL:
-		var lambdaFunctionURLReq events.LambdaFunctionURLRequest
-		if err := json.Unmarshal(req, &lambdaFunctionURLReq); err != nil {
-			return events.LambdaFunctionURLResponse{StatusCode: 400, Body: "Unsupported request type"}, nil
-		}
-		return handleLambdaFunctionURLRequest(lambdaFunctionURLReq, plugins)
+	var evt lambdaHTTPEvent
+	if err := json.Unmarshal(req, &evt); err != nil {
+		return events.LambdaFunctionURLResponse{StatusCode: 400, Body: "Unsupported request type"}, nil
+	}
+
+	switch {
+	case evt.HTTPMethod != "":
+		return handleAPIGatewayProxyRequest(evt, plugins)
+	case evt.RequestContext.HTTP.Method != "":
+		return handleLambdaFunctionURLRequest(evt, plugins)
 	default:
 		return events.LambdaFunctionURLResponse{StatusCode: 400, Body: "Unsupported request type"}, nil
 	}
 }
 
-// handleAPIGatewayProxyRequest processes API Gateway Proxy requests.
-func handleAPIGatewayProxyRequest(req events.APIGatewayProxyRequest, plugins []plugin.Plugin) (events.APIGatewayProxyResponse, error) {
+// handleAPIGatewayProxyRequest processes API Gateway proxy (v1) requests.
+func handleAPIGatewayProxyRequest(evt lambdaHTTPEvent, plugins []plugin.Plugin) (events.APIGatewayProxyResponse, error) {
 	// Decode the body first: API Gateway base64-encodes binary payloads (e.g.
 	// file uploads and multipart bodies) and sets IsBase64Encoded accordingly.
-	body, err := decodeLambdaBody(req.Body, req.IsBase64Encoded)
+	body, err := decodeLambdaBody(evt.Body, evt.IsBase64Encoded)
 	if err != nil {
 		return events.APIGatewayProxyResponse{StatusCode: 400, Body: "Failed to decode request body"}, nil
 	}
 
-	// Convert APIGatewayProxyRequest to http.Request, preserving query parameters
-	// and headers so that route matching and script access (queryParams, headers,
-	// formParams derived from the body) work.
-	httpReq, err := convertLambdaRequestToHTTPRequest(req.HTTPMethod, req.Path, buildAPIGatewayQueryString(req), buildAPIGatewayHeaders(req), body)
+	// Preserve query parameters and headers so that route matching and script
+	// access (queryParams, headers, formParams derived from the body) work.
+	httpReq, err := convertLambdaRequestToHTTPRequest(evt.HTTPMethod, evt.Path, buildAPIGatewayQueryString(evt), buildAPIGatewayHeaders(evt), body)
 	if err != nil {
 		return events.APIGatewayProxyResponse{StatusCode: 500, Body: "Failed to convert request"}, nil
 	}
@@ -164,20 +159,20 @@ func handleAPIGatewayProxyRequest(req events.APIGatewayProxyRequest, plugins []p
 	return convertHTTPResponseToLambdaResponse(recorder), nil
 }
 
-// handleLambdaFunctionURLRequest processes Lambda Function URL requests.
-func handleLambdaFunctionURLRequest(req events.LambdaFunctionURLRequest, plugins []plugin.Plugin) (events.LambdaFunctionURLResponse, error) {
+// handleLambdaFunctionURLRequest processes Function URL / API Gateway HTTP API
+// (v2) requests.
+func handleLambdaFunctionURLRequest(evt lambdaHTTPEvent, plugins []plugin.Plugin) (events.LambdaFunctionURLResponse, error) {
 	// Decode the body first: the v2 payload base64-encodes binary payloads (e.g.
 	// file uploads and multipart bodies) and sets IsBase64Encoded accordingly.
-	body, err := decodeLambdaBody(req.Body, req.IsBase64Encoded)
+	body, err := decodeLambdaBody(evt.Body, evt.IsBase64Encoded)
 	if err != nil {
 		return events.LambdaFunctionURLResponse{StatusCode: 400, Body: "Failed to decode request body"}, nil
 	}
 
-	// Convert LambdaFunctionURLRequest to http.Request. RawQueryString is already
-	// URL-encoded in the v2 payload, so it can be used directly as the raw query.
-	// Cookies arrive in a separate array (not the headers map) and are folded
-	// back into a Cookie header by buildFunctionURLHeaders.
-	httpReq, err := convertLambdaRequestToHTTPRequest(req.RequestContext.HTTP.Method, req.RawPath, req.RawQueryString, buildFunctionURLHeaders(req), body)
+	// RawQueryString is already URL-encoded in the v2 payload, so it is used
+	// directly. Cookies arrive in a separate array (not the headers map) and are
+	// folded back into a Cookie header by buildFunctionURLHeaders.
+	httpReq, err := convertLambdaRequestToHTTPRequest(evt.RequestContext.HTTP.Method, evt.RawPath, evt.RawQueryString, buildFunctionURLHeaders(evt), body)
 	if err != nil {
 		return events.LambdaFunctionURLResponse{StatusCode: 500, Body: "Failed to convert request"}, nil
 	}
@@ -227,20 +222,20 @@ func decodeLambdaBody(body string, isBase64 bool) ([]byte, error) {
 }
 
 // buildAPIGatewayQueryString reconstructs an encoded query string from an API
-// Gateway proxy (v1) request. Parameter values in the event are already
+// Gateway proxy (v1) event. Parameter values in the event are already
 // URL-decoded, so they are re-encoded here. MultiValueQueryStringParameters is
 // preferred when present because it preserves repeated keys (e.g. ?foo=a&foo=b);
 // otherwise the single-valued QueryStringParameters map is used.
-func buildAPIGatewayQueryString(req events.APIGatewayProxyRequest) string {
+func buildAPIGatewayQueryString(evt lambdaHTTPEvent) string {
 	values := url.Values{}
-	if len(req.MultiValueQueryStringParameters) > 0 {
-		for key, vals := range req.MultiValueQueryStringParameters {
+	if len(evt.MultiValueQueryStringParameters) > 0 {
+		for key, vals := range evt.MultiValueQueryStringParameters {
 			for _, v := range vals {
 				values.Add(key, v)
 			}
 		}
 	} else {
-		for key, v := range req.QueryStringParameters {
+		for key, v := range evt.QueryStringParameters {
 			values.Set(key, v)
 		}
 	}
@@ -251,16 +246,16 @@ func buildAPIGatewayQueryString(req events.APIGatewayProxyRequest) string {
 // (v1) event to http.Header. MultiValueHeaders is preferred when present so
 // repeated headers (e.g. multiple Cookie or Accept values) are preserved;
 // otherwise the single-valued Headers map is used.
-func buildAPIGatewayHeaders(req events.APIGatewayProxyRequest) http.Header {
+func buildAPIGatewayHeaders(evt lambdaHTTPEvent) http.Header {
 	header := make(http.Header)
-	if len(req.MultiValueHeaders) > 0 {
-		for key, vals := range req.MultiValueHeaders {
+	if len(evt.MultiValueHeaders) > 0 {
+		for key, vals := range evt.MultiValueHeaders {
 			for _, v := range vals {
 				header.Add(key, v)
 			}
 		}
 	} else {
-		for key, v := range req.Headers {
+		for key, v := range evt.Headers {
 			header.Set(key, v)
 		}
 	}
@@ -271,13 +266,13 @@ func buildAPIGatewayHeaders(req events.APIGatewayProxyRequest) http.Header {
 // / API Gateway HTTP API (v2) event to http.Header. In the v2 payload format
 // cookies are delivered in a separate Cookies array rather than the headers
 // map, so they are recombined into a single Cookie header (RFC 6265).
-func buildFunctionURLHeaders(req events.LambdaFunctionURLRequest) http.Header {
+func buildFunctionURLHeaders(evt lambdaHTTPEvent) http.Header {
 	header := make(http.Header)
-	for key, v := range req.Headers {
+	for key, v := range evt.Headers {
 		header.Set(key, v)
 	}
-	if len(req.Cookies) > 0 {
-		header.Set("Cookie", strings.Join(req.Cookies, "; "))
+	if len(evt.Cookies) > 0 {
+		header.Set("Cookie", strings.Join(evt.Cookies, "; "))
 	}
 	return header
 }

--- a/internal/adapter/awslambda/awslambda.go
+++ b/internal/adapter/awslambda/awslambda.go
@@ -80,16 +80,57 @@ func init() {
 	}
 }
 
+// lambdaEventType identifies which Lambda HTTP event shape a payload carries.
+type lambdaEventType int
+
+const (
+	eventUnknown lambdaEventType = iota
+	eventAPIGatewayProxy
+	eventLambdaFunctionURL
+)
+
+// detectLambdaEventType inspects only the discriminating fields of the payload
+// so the full event is decoded once, into the correct type. API Gateway proxy
+// (v1) carries a top-level httpMethod; Function URL / API Gateway HTTP API (v2)
+// carries requestContext.http.method instead.
+func detectLambdaEventType(req json.RawMessage) lambdaEventType {
+	var probe struct {
+		HTTPMethod     string `json:"httpMethod"`
+		RequestContext struct {
+			HTTP struct {
+				Method string `json:"method"`
+			} `json:"http"`
+		} `json:"requestContext"`
+	}
+	if err := json.Unmarshal(req, &probe); err != nil {
+		return eventUnknown
+	}
+	switch {
+	case probe.HTTPMethod != "":
+		return eventAPIGatewayProxy
+	case probe.RequestContext.HTTP.Method != "":
+		return eventLambdaFunctionURL
+	default:
+		return eventUnknown
+	}
+}
+
 // HandleLambdaRequest handles incoming Lambda requests and routes them to the appropriate handler.
 func HandleLambdaRequest(req json.RawMessage) (interface{}, error) {
-	var apiGatewayReq events.APIGatewayProxyRequest
-	var lambdaFunctionURLReq events.LambdaFunctionURLRequest
-
-	if err := json.Unmarshal(req, &apiGatewayReq); err == nil && apiGatewayReq.HTTPMethod != "" {
+	switch detectLambdaEventType(req) {
+	case eventAPIGatewayProxy:
+		var apiGatewayReq events.APIGatewayProxyRequest
+		if err := json.Unmarshal(req, &apiGatewayReq); err != nil {
+			return events.APIGatewayProxyResponse{StatusCode: 400, Body: "Unsupported request type"}, nil
+		}
 		return handleAPIGatewayProxyRequest(apiGatewayReq, plugins)
-	} else if err := json.Unmarshal(req, &lambdaFunctionURLReq); err == nil && lambdaFunctionURLReq.RequestContext.HTTP.Method != "" {
+	case eventLambdaFunctionURL:
+		var lambdaFunctionURLReq events.LambdaFunctionURLRequest
+		if err := json.Unmarshal(req, &lambdaFunctionURLReq); err != nil {
+			return events.LambdaFunctionURLResponse{StatusCode: 400, Body: "Unsupported request type"}, nil
+		}
 		return handleLambdaFunctionURLRequest(lambdaFunctionURLReq, plugins)
-	} else {
+	default:
 		return events.LambdaFunctionURLResponse{StatusCode: 400, Body: "Unsupported request type"}, nil
 	}
 }

--- a/internal/adapter/awslambda/awslambda.go
+++ b/internal/adapter/awslambda/awslambda.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -95,8 +96,9 @@ func HandleLambdaRequest(req json.RawMessage) (interface{}, error) {
 
 // handleAPIGatewayProxyRequest processes API Gateway Proxy requests.
 func handleAPIGatewayProxyRequest(req events.APIGatewayProxyRequest, plugins []plugin.Plugin) (events.APIGatewayProxyResponse, error) {
-	// Convert APIGatewayProxyRequest to http.Request
-	httpReq, err := convertLambdaRequestToHTTPRequest(req.HTTPMethod, req.Path, req.Headers, req.Body)
+	// Convert APIGatewayProxyRequest to http.Request, preserving query parameters
+	// so that route matching and script access (context.request.queryParams) work.
+	httpReq, err := convertLambdaRequestToHTTPRequest(req.HTTPMethod, req.Path, buildAPIGatewayQueryString(req), req.Headers, req.Body)
 	if err != nil {
 		return events.APIGatewayProxyResponse{StatusCode: 500, Body: "Failed to convert request"}, nil
 	}
@@ -115,8 +117,9 @@ func handleAPIGatewayProxyRequest(req events.APIGatewayProxyRequest, plugins []p
 
 // handleLambdaFunctionURLRequest processes Lambda Function URL requests.
 func handleLambdaFunctionURLRequest(req events.LambdaFunctionURLRequest, plugins []plugin.Plugin) (events.LambdaFunctionURLResponse, error) {
-	// Convert LambdaFunctionURLRequest to http.Request
-	httpReq, err := convertLambdaRequestToHTTPRequest(req.RequestContext.HTTP.Method, req.RawPath, req.Headers, req.Body)
+	// Convert LambdaFunctionURLRequest to http.Request. RawQueryString is already
+	// URL-encoded in the v2 payload, so it can be used directly as the raw query.
+	httpReq, err := convertLambdaRequestToHTTPRequest(req.RequestContext.HTTP.Method, req.RawPath, req.RawQueryString, req.Headers, req.Body)
 	if err != nil {
 		return events.LambdaFunctionURLResponse{StatusCode: 500, Body: "Failed to convert request"}, nil
 	}
@@ -134,11 +137,16 @@ func handleLambdaFunctionURLRequest(req events.LambdaFunctionURLRequest, plugins
 }
 
 // convertLambdaRequestToHTTPRequest converts a Lambda request to an http.Request.
-func convertLambdaRequestToHTTPRequest(method, path string, headers map[string]string, body string) (*http.Request, error) {
+// rawQuery is the URL-encoded query string (without the leading '?'); it is set
+// on the request URL so downstream matching and scripts can read query parameters.
+func convertLambdaRequestToHTTPRequest(method, path, rawQuery string, headers map[string]string, body string) (*http.Request, error) {
 	bodyReader := strings.NewReader(body)
 	httpReq, err := http.NewRequest(method, path, bodyReader)
 	if err != nil {
 		return nil, err
+	}
+	if rawQuery != "" {
+		httpReq.URL.RawQuery = rawQuery
 	}
 
 	for key, value := range headers {
@@ -146,6 +154,27 @@ func convertLambdaRequestToHTTPRequest(method, path string, headers map[string]s
 	}
 
 	return httpReq, nil
+}
+
+// buildAPIGatewayQueryString reconstructs an encoded query string from an API
+// Gateway proxy (v1) request. Parameter values in the event are already
+// URL-decoded, so they are re-encoded here. MultiValueQueryStringParameters is
+// preferred when present because it preserves repeated keys (e.g. ?foo=a&foo=b);
+// otherwise the single-valued QueryStringParameters map is used.
+func buildAPIGatewayQueryString(req events.APIGatewayProxyRequest) string {
+	values := url.Values{}
+	if len(req.MultiValueQueryStringParameters) > 0 {
+		for key, vals := range req.MultiValueQueryStringParameters {
+			for _, v := range vals {
+				values.Add(key, v)
+			}
+		}
+	} else {
+		for key, v := range req.QueryStringParameters {
+			values.Set(key, v)
+		}
+	}
+	return values.Encode()
 }
 
 // convertHTTPResponseToLambdaResponse converts an http.Response to an APIGatewayProxyResponse.

--- a/internal/adapter/awslambda/awslambda.go
+++ b/internal/adapter/awslambda/awslambda.go
@@ -96,9 +96,17 @@ func HandleLambdaRequest(req json.RawMessage) (interface{}, error) {
 
 // handleAPIGatewayProxyRequest processes API Gateway Proxy requests.
 func handleAPIGatewayProxyRequest(req events.APIGatewayProxyRequest, plugins []plugin.Plugin) (events.APIGatewayProxyResponse, error) {
+	// Decode the body first: API Gateway base64-encodes binary payloads (e.g.
+	// file uploads and multipart bodies) and sets IsBase64Encoded accordingly.
+	body, err := decodeLambdaBody(req.Body, req.IsBase64Encoded)
+	if err != nil {
+		return events.APIGatewayProxyResponse{StatusCode: 400, Body: "Failed to decode request body"}, nil
+	}
+
 	// Convert APIGatewayProxyRequest to http.Request, preserving query parameters
-	// so that route matching and script access (context.request.queryParams) work.
-	httpReq, err := convertLambdaRequestToHTTPRequest(req.HTTPMethod, req.Path, buildAPIGatewayQueryString(req), req.Headers, req.Body)
+	// and headers so that route matching and script access (queryParams, headers,
+	// formParams derived from the body) work.
+	httpReq, err := convertLambdaRequestToHTTPRequest(req.HTTPMethod, req.Path, buildAPIGatewayQueryString(req), buildAPIGatewayHeaders(req), body)
 	if err != nil {
 		return events.APIGatewayProxyResponse{StatusCode: 500, Body: "Failed to convert request"}, nil
 	}
@@ -117,9 +125,18 @@ func handleAPIGatewayProxyRequest(req events.APIGatewayProxyRequest, plugins []p
 
 // handleLambdaFunctionURLRequest processes Lambda Function URL requests.
 func handleLambdaFunctionURLRequest(req events.LambdaFunctionURLRequest, plugins []plugin.Plugin) (events.LambdaFunctionURLResponse, error) {
+	// Decode the body first: the v2 payload base64-encodes binary payloads (e.g.
+	// file uploads and multipart bodies) and sets IsBase64Encoded accordingly.
+	body, err := decodeLambdaBody(req.Body, req.IsBase64Encoded)
+	if err != nil {
+		return events.LambdaFunctionURLResponse{StatusCode: 400, Body: "Failed to decode request body"}, nil
+	}
+
 	// Convert LambdaFunctionURLRequest to http.Request. RawQueryString is already
 	// URL-encoded in the v2 payload, so it can be used directly as the raw query.
-	httpReq, err := convertLambdaRequestToHTTPRequest(req.RequestContext.HTTP.Method, req.RawPath, req.RawQueryString, req.Headers, req.Body)
+	// Cookies arrive in a separate array (not the headers map) and are folded
+	// back into a Cookie header by buildFunctionURLHeaders.
+	httpReq, err := convertLambdaRequestToHTTPRequest(req.RequestContext.HTTP.Method, req.RawPath, req.RawQueryString, buildFunctionURLHeaders(req), body)
 	if err != nil {
 		return events.LambdaFunctionURLResponse{StatusCode: 500, Body: "Failed to convert request"}, nil
 	}
@@ -137,23 +154,35 @@ func handleLambdaFunctionURLRequest(req events.LambdaFunctionURLRequest, plugins
 }
 
 // convertLambdaRequestToHTTPRequest converts a Lambda request to an http.Request.
-// rawQuery is the URL-encoded query string (without the leading '?'); it is set
-// on the request URL so downstream matching and scripts can read query parameters.
-func convertLambdaRequestToHTTPRequest(method, path, rawQuery string, headers map[string]string, body string) (*http.Request, error) {
-	bodyReader := strings.NewReader(body)
-	httpReq, err := http.NewRequest(method, path, bodyReader)
+// rawQuery is the URL-encoded query string (without the leading '?') and is set
+// on the request URL so downstream matching and scripts can read query
+// parameters. body is the already-decoded request body; header carries the
+// request headers (including any recombined cookies).
+func convertLambdaRequestToHTTPRequest(method, path, rawQuery string, header http.Header, body []byte) (*http.Request, error) {
+	httpReq, err := http.NewRequest(method, path, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
 	if rawQuery != "" {
 		httpReq.URL.RawQuery = rawQuery
 	}
-
-	for key, value := range headers {
-		httpReq.Header.Set(key, value)
+	if header != nil {
+		httpReq.Header = header
 	}
 
 	return httpReq, nil
+}
+
+// decodeLambdaBody returns the request body bytes, base64-decoding them when the
+// Lambda event marks the body as base64-encoded. API Gateway and Function URLs
+// base64-encode binary request payloads (e.g. file uploads, multipart bodies,
+// non-UTF-8 content); passing the raw base64 string downstream would corrupt
+// body matching and form parsing.
+func decodeLambdaBody(body string, isBase64 bool) ([]byte, error) {
+	if !isBase64 {
+		return []byte(body), nil
+	}
+	return base64.StdEncoding.DecodeString(body)
 }
 
 // buildAPIGatewayQueryString reconstructs an encoded query string from an API
@@ -175,6 +204,41 @@ func buildAPIGatewayQueryString(req events.APIGatewayProxyRequest) string {
 		}
 	}
 	return values.Encode()
+}
+
+// buildAPIGatewayHeaders converts the request headers of an API Gateway proxy
+// (v1) event to http.Header. MultiValueHeaders is preferred when present so
+// repeated headers (e.g. multiple Cookie or Accept values) are preserved;
+// otherwise the single-valued Headers map is used.
+func buildAPIGatewayHeaders(req events.APIGatewayProxyRequest) http.Header {
+	header := make(http.Header)
+	if len(req.MultiValueHeaders) > 0 {
+		for key, vals := range req.MultiValueHeaders {
+			for _, v := range vals {
+				header.Add(key, v)
+			}
+		}
+	} else {
+		for key, v := range req.Headers {
+			header.Set(key, v)
+		}
+	}
+	return header
+}
+
+// buildFunctionURLHeaders converts the request headers of a Lambda Function URL
+// / API Gateway HTTP API (v2) event to http.Header. In the v2 payload format
+// cookies are delivered in a separate Cookies array rather than the headers
+// map, so they are recombined into a single Cookie header (RFC 6265).
+func buildFunctionURLHeaders(req events.LambdaFunctionURLRequest) http.Header {
+	header := make(http.Header)
+	for key, v := range req.Headers {
+		header.Set(key, v)
+	}
+	if len(req.Cookies) > 0 {
+		header.Set("Cookie", strings.Join(req.Cookies, "; "))
+	}
+	return header
 }
 
 // convertHTTPResponseToLambdaResponse converts an http.Response to an APIGatewayProxyResponse.

--- a/internal/adapter/awslambda/awslambda_test.go
+++ b/internal/adapter/awslambda/awslambda_test.go
@@ -2,6 +2,7 @@ package awslambda
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"io"
 	"net/http"
 	"testing"
@@ -10,6 +11,26 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDetectLambdaEventType_APIGatewayProxy(t *testing.T) {
+	// v1 payload: top-level httpMethod.
+	payload := json.RawMessage(`{"httpMethod":"GET","path":"/api","queryStringParameters":{"foo":"bar"}}`)
+	assert.Equal(t, eventAPIGatewayProxy, detectLambdaEventType(payload))
+}
+
+func TestDetectLambdaEventType_LambdaFunctionURL(t *testing.T) {
+	// v2 payload: no top-level httpMethod, method is under requestContext.http.
+	payload := json.RawMessage(`{"version":"2.0","rawPath":"/api","requestContext":{"http":{"method":"POST"}}}`)
+	assert.Equal(t, eventLambdaFunctionURL, detectLambdaEventType(payload))
+}
+
+func TestDetectLambdaEventType_Unknown(t *testing.T) {
+	assert.Equal(t, eventUnknown, detectLambdaEventType(json.RawMessage(`{"foo":"bar"}`)))
+}
+
+func TestDetectLambdaEventType_InvalidJSON(t *testing.T) {
+	assert.Equal(t, eventUnknown, detectLambdaEventType(json.RawMessage(`not json`)))
+}
 
 func TestConvertLambdaRequestToHTTPRequest_WithQuery(t *testing.T) {
 	httpReq, err := convertLambdaRequestToHTTPRequest("GET", "/api/endpoint", "foo=bar&baz=qux", nil, nil)

--- a/internal/adapter/awslambda/awslambda_test.go
+++ b/internal/adapter/awslambda/awslambda_test.go
@@ -1,6 +1,9 @@
 package awslambda
 
 import (
+	"encoding/base64"
+	"io"
+	"net/http"
 	"testing"
 
 	"github.com/aws/aws-lambda-go/events"
@@ -9,7 +12,7 @@ import (
 )
 
 func TestConvertLambdaRequestToHTTPRequest_WithQuery(t *testing.T) {
-	httpReq, err := convertLambdaRequestToHTTPRequest("GET", "/api/endpoint", "foo=bar&baz=qux", nil, "")
+	httpReq, err := convertLambdaRequestToHTTPRequest("GET", "/api/endpoint", "foo=bar&baz=qux", nil, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, "/api/endpoint", httpReq.URL.Path)
@@ -20,7 +23,7 @@ func TestConvertLambdaRequestToHTTPRequest_WithQuery(t *testing.T) {
 }
 
 func TestConvertLambdaRequestToHTTPRequest_WithoutQuery(t *testing.T) {
-	httpReq, err := convertLambdaRequestToHTTPRequest("GET", "/api/endpoint", "", nil, "")
+	httpReq, err := convertLambdaRequestToHTTPRequest("GET", "/api/endpoint", "", nil, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, "/api/endpoint", httpReq.URL.Path)
@@ -30,10 +33,22 @@ func TestConvertLambdaRequestToHTTPRequest_WithoutQuery(t *testing.T) {
 
 func TestConvertLambdaRequestToHTTPRequest_EncodedQueryRoundTrips(t *testing.T) {
 	// A raw query with an encoded space and ampersand should decode correctly.
-	httpReq, err := convertLambdaRequestToHTTPRequest("GET", "/search", "q=hello+world%26more", nil, "")
+	httpReq, err := convertLambdaRequestToHTTPRequest("GET", "/search", "q=hello+world%26more", nil, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, "hello world&more", httpReq.URL.Query().Get("q"))
+}
+
+func TestConvertLambdaRequestToHTTPRequest_BodyAndHeaders(t *testing.T) {
+	header := http.Header{}
+	header.Set("Content-Type", "application/json")
+	httpReq, err := convertLambdaRequestToHTTPRequest("POST", "/api", "", header, []byte(`{"key":"value"}`))
+	require.NoError(t, err)
+
+	assert.Equal(t, "application/json", httpReq.Header.Get("Content-Type"))
+	got, err := io.ReadAll(httpReq.Body)
+	require.NoError(t, err)
+	assert.Equal(t, `{"key":"value"}`, string(got))
 }
 
 func TestBuildAPIGatewayQueryString_SingleValue(t *testing.T) {
@@ -54,7 +69,7 @@ func TestBuildAPIGatewayQueryString_EncodesSpecialCharacters(t *testing.T) {
 
 	raw := buildAPIGatewayQueryString(req)
 
-	httpReq, err := convertLambdaRequestToHTTPRequest("GET", "/search", raw, nil, "")
+	httpReq, err := convertLambdaRequestToHTTPRequest("GET", "/search", raw, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "hello world&more", httpReq.URL.Query().Get("q"))
 }
@@ -69,7 +84,7 @@ func TestBuildAPIGatewayQueryString_MultiValuePreferred(t *testing.T) {
 
 	raw := buildAPIGatewayQueryString(req)
 
-	httpReq, err := convertLambdaRequestToHTTPRequest("GET", "/api", raw, nil, "")
+	httpReq, err := convertLambdaRequestToHTTPRequest("GET", "/api", raw, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"a", "b"}, httpReq.URL.Query()["foo"])
 }
@@ -79,6 +94,87 @@ func TestBuildAPIGatewayQueryString_Empty(t *testing.T) {
 	assert.Equal(t, "", buildAPIGatewayQueryString(req))
 }
 
+func TestDecodeLambdaBody_PlainText(t *testing.T) {
+	body, err := decodeLambdaBody("hello world", false)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hello world"), body)
+}
+
+func TestDecodeLambdaBody_Base64Binary(t *testing.T) {
+	binary := []byte{0x00, 0x01, 0x02, 0xFF, 0xFE}
+	encoded := base64.StdEncoding.EncodeToString(binary)
+
+	body, err := decodeLambdaBody(encoded, true)
+	require.NoError(t, err)
+	assert.Equal(t, binary, body)
+}
+
+func TestDecodeLambdaBody_InvalidBase64(t *testing.T) {
+	_, err := decodeLambdaBody("not-valid-base64!!!", true)
+	assert.Error(t, err)
+}
+
+func TestBuildAPIGatewayHeaders_SingleValue(t *testing.T) {
+	req := events.APIGatewayProxyRequest{
+		Headers: map[string]string{"Content-Type": "application/json"},
+	}
+
+	header := buildAPIGatewayHeaders(req)
+	assert.Equal(t, "application/json", header.Get("Content-Type"))
+}
+
+func TestBuildAPIGatewayHeaders_MultiValuePreferred(t *testing.T) {
+	req := events.APIGatewayProxyRequest{
+		Headers: map[string]string{"X-Custom": "single"},
+		MultiValueHeaders: map[string][]string{
+			"X-Custom": {"a", "b"},
+		},
+	}
+
+	header := buildAPIGatewayHeaders(req)
+	assert.Equal(t, []string{"a", "b"}, header.Values("X-Custom"))
+}
+
+func TestBuildFunctionURLHeaders_FoldsCookies(t *testing.T) {
+	req := events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"Content-Type": "text/plain"},
+		Cookies: []string{"session=abc", "theme=dark"},
+	}
+
+	header := buildFunctionURLHeaders(req)
+	assert.Equal(t, "text/plain", header.Get("Content-Type"))
+	assert.Equal(t, "session=abc; theme=dark", header.Get("Cookie"))
+}
+
+func TestBuildFunctionURLHeaders_NoCookies(t *testing.T) {
+	req := events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"Accept": "application/json"},
+	}
+
+	header := buildFunctionURLHeaders(req)
+	assert.Equal(t, "application/json", header.Get("Accept"))
+	assert.Empty(t, header.Get("Cookie"))
+}
+
+// TestFunctionURLCookiesReadableAsCookie verifies the folded Cookie header is
+// parseable by the standard library, so downstream cookie access works.
+func TestFunctionURLCookiesReadableAsCookie(t *testing.T) {
+	req := events.LambdaFunctionURLRequest{
+		RawPath: "/api",
+		Cookies: []string{"session=abc", "theme=dark"},
+	}
+
+	httpReq, err := convertLambdaRequestToHTTPRequest(req.RequestContext.HTTP.Method, req.RawPath, req.RawQueryString, buildFunctionURLHeaders(req), nil)
+	require.NoError(t, err)
+
+	c, err := httpReq.Cookie("session")
+	require.NoError(t, err)
+	assert.Equal(t, "abc", c.Value)
+	c, err = httpReq.Cookie("theme")
+	require.NoError(t, err)
+	assert.Equal(t, "dark", c.Value)
+}
+
 func TestHandleAPIGatewayProxyRequest_PreservesQueryParams(t *testing.T) {
 	req := events.APIGatewayProxyRequest{
 		HTTPMethod:            "GET",
@@ -86,9 +182,50 @@ func TestHandleAPIGatewayProxyRequest_PreservesQueryParams(t *testing.T) {
 		QueryStringParameters: map[string]string{"foo": "bar"},
 	}
 
-	httpReq, err := convertLambdaRequestToHTTPRequest(req.HTTPMethod, req.Path, buildAPIGatewayQueryString(req), req.Headers, req.Body)
+	httpReq, err := convertLambdaRequestToHTTPRequest(req.HTTPMethod, req.Path, buildAPIGatewayQueryString(req), buildAPIGatewayHeaders(req), []byte(req.Body))
 	require.NoError(t, err)
 	assert.Equal(t, "bar", httpReq.URL.Query().Get("foo"))
+}
+
+// TestFormURLEncodedBodyParses exercises the full path a form POST takes: the
+// body and Content-Type header must survive conversion so ParseForm works.
+func TestFormURLEncodedBodyParses(t *testing.T) {
+	req := events.APIGatewayProxyRequest{
+		HTTPMethod: "POST",
+		Path:       "/submit",
+		Headers:    map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
+		Body:       "name=alice&role=admin",
+	}
+
+	body, err := decodeLambdaBody(req.Body, req.IsBase64Encoded)
+	require.NoError(t, err)
+	httpReq, err := convertLambdaRequestToHTTPRequest(req.HTTPMethod, req.Path, buildAPIGatewayQueryString(req), buildAPIGatewayHeaders(req), body)
+	require.NoError(t, err)
+
+	require.NoError(t, httpReq.ParseForm())
+	assert.Equal(t, "alice", httpReq.PostFormValue("name"))
+	assert.Equal(t, "admin", httpReq.PostFormValue("role"))
+}
+
+// TestBase64FormBodyParses verifies a base64-encoded form body (as API Gateway
+// delivers binary/opaque payloads) is decoded before form parsing.
+func TestBase64FormBodyParses(t *testing.T) {
+	req := events.APIGatewayProxyRequest{
+		HTTPMethod:      "POST",
+		Path:            "/submit",
+		Headers:         map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
+		Body:            base64.StdEncoding.EncodeToString([]byte("name=bob&role=user")),
+		IsBase64Encoded: true,
+	}
+
+	body, err := decodeLambdaBody(req.Body, req.IsBase64Encoded)
+	require.NoError(t, err)
+	httpReq, err := convertLambdaRequestToHTTPRequest(req.HTTPMethod, req.Path, buildAPIGatewayQueryString(req), buildAPIGatewayHeaders(req), body)
+	require.NoError(t, err)
+
+	require.NoError(t, httpReq.ParseForm())
+	assert.Equal(t, "bob", httpReq.PostFormValue("name"))
+	assert.Equal(t, "user", httpReq.PostFormValue("role"))
 }
 
 func TestHandleLambdaFunctionURLRequest_PreservesQueryParams(t *testing.T) {
@@ -97,7 +234,7 @@ func TestHandleLambdaFunctionURLRequest_PreservesQueryParams(t *testing.T) {
 		RawQueryString: "foo=bar&baz=qux",
 	}
 
-	httpReq, err := convertLambdaRequestToHTTPRequest(req.RequestContext.HTTP.Method, req.RawPath, req.RawQueryString, req.Headers, req.Body)
+	httpReq, err := convertLambdaRequestToHTTPRequest(req.RequestContext.HTTP.Method, req.RawPath, req.RawQueryString, buildFunctionURLHeaders(req), []byte(req.Body))
 	require.NoError(t, err)
 	assert.Equal(t, "bar", httpReq.URL.Query().Get("foo"))
 	assert.Equal(t, "qux", httpReq.URL.Query().Get("baz"))

--- a/internal/adapter/awslambda/awslambda_test.go
+++ b/internal/adapter/awslambda/awslambda_test.go
@@ -7,29 +7,56 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/aws/aws-lambda-go/events"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestDetectLambdaEventType_APIGatewayProxy(t *testing.T) {
-	// v1 payload: top-level httpMethod.
-	payload := json.RawMessage(`{"httpMethod":"GET","path":"/api","queryStringParameters":{"foo":"bar"}}`)
-	assert.Equal(t, eventAPIGatewayProxy, detectLambdaEventType(payload))
+// TestLambdaHTTPEvent_DecodesAPIGatewayV1 verifies a v1 payload maps onto the
+// unified event with a single decode, and is distinguishable as v1.
+func TestLambdaHTTPEvent_DecodesAPIGatewayV1(t *testing.T) {
+	payload := []byte(`{
+		"httpMethod":"GET",
+		"path":"/api",
+		"headers":{"Content-Type":"application/json"},
+		"multiValueHeaders":{"X-Custom":["a","b"]},
+		"queryStringParameters":{"foo":"bar"},
+		"multiValueQueryStringParameters":{"foo":["a","b"]},
+		"body":"hello",
+		"isBase64Encoded":false
+	}`)
+
+	var evt lambdaHTTPEvent
+	require.NoError(t, json.Unmarshal(payload, &evt))
+
+	assert.Equal(t, "GET", evt.HTTPMethod)
+	assert.Empty(t, evt.RequestContext.HTTP.Method) // not a v2 event
+	assert.Equal(t, "/api", evt.Path)
+	assert.Equal(t, "bar", evt.QueryStringParameters["foo"])
+	assert.Equal(t, []string{"a", "b"}, evt.MultiValueHeaders["X-Custom"])
+	assert.Equal(t, "hello", evt.Body)
 }
 
-func TestDetectLambdaEventType_LambdaFunctionURL(t *testing.T) {
-	// v2 payload: no top-level httpMethod, method is under requestContext.http.
-	payload := json.RawMessage(`{"version":"2.0","rawPath":"/api","requestContext":{"http":{"method":"POST"}}}`)
-	assert.Equal(t, eventLambdaFunctionURL, detectLambdaEventType(payload))
-}
+// TestLambdaHTTPEvent_DecodesFunctionURLV2 verifies a v2 payload maps onto the
+// unified event with a single decode, and is distinguishable as v2.
+func TestLambdaHTTPEvent_DecodesFunctionURLV2(t *testing.T) {
+	payload := []byte(`{
+		"version":"2.0",
+		"rawPath":"/api",
+		"rawQueryString":"foo=bar",
+		"cookies":["session=abc","theme=dark"],
+		"headers":{"content-type":"text/plain"},
+		"requestContext":{"http":{"method":"POST"}},
+		"body":"hi"
+	}`)
 
-func TestDetectLambdaEventType_Unknown(t *testing.T) {
-	assert.Equal(t, eventUnknown, detectLambdaEventType(json.RawMessage(`{"foo":"bar"}`)))
-}
+	var evt lambdaHTTPEvent
+	require.NoError(t, json.Unmarshal(payload, &evt))
 
-func TestDetectLambdaEventType_InvalidJSON(t *testing.T) {
-	assert.Equal(t, eventUnknown, detectLambdaEventType(json.RawMessage(`not json`)))
+	assert.Empty(t, evt.HTTPMethod) // not a v1 event
+	assert.Equal(t, "POST", evt.RequestContext.HTTP.Method)
+	assert.Equal(t, "/api", evt.RawPath)
+	assert.Equal(t, "foo=bar", evt.RawQueryString)
+	assert.Equal(t, []string{"session=abc", "theme=dark"}, evt.Cookies)
 }
 
 func TestConvertLambdaRequestToHTTPRequest_WithQuery(t *testing.T) {
@@ -73,22 +100,22 @@ func TestConvertLambdaRequestToHTTPRequest_BodyAndHeaders(t *testing.T) {
 }
 
 func TestBuildAPIGatewayQueryString_SingleValue(t *testing.T) {
-	req := events.APIGatewayProxyRequest{
+	evt := lambdaHTTPEvent{
 		QueryStringParameters: map[string]string{"foo": "bar"},
 	}
 
-	raw := buildAPIGatewayQueryString(req)
+	raw := buildAPIGatewayQueryString(evt)
 	assert.Equal(t, "foo=bar", raw)
 }
 
 func TestBuildAPIGatewayQueryString_EncodesSpecialCharacters(t *testing.T) {
 	// The event delivers already-decoded values; the reconstructed query string
 	// must re-encode them so they round-trip through url.Query().
-	req := events.APIGatewayProxyRequest{
+	evt := lambdaHTTPEvent{
 		QueryStringParameters: map[string]string{"q": "hello world&more"},
 	}
 
-	raw := buildAPIGatewayQueryString(req)
+	raw := buildAPIGatewayQueryString(evt)
 
 	httpReq, err := convertLambdaRequestToHTTPRequest("GET", "/search", raw, nil, nil)
 	require.NoError(t, err)
@@ -96,14 +123,14 @@ func TestBuildAPIGatewayQueryString_EncodesSpecialCharacters(t *testing.T) {
 }
 
 func TestBuildAPIGatewayQueryString_MultiValuePreferred(t *testing.T) {
-	req := events.APIGatewayProxyRequest{
+	evt := lambdaHTTPEvent{
 		QueryStringParameters: map[string]string{"foo": "b"},
 		MultiValueQueryStringParameters: map[string][]string{
 			"foo": {"a", "b"},
 		},
 	}
 
-	raw := buildAPIGatewayQueryString(req)
+	raw := buildAPIGatewayQueryString(evt)
 
 	httpReq, err := convertLambdaRequestToHTTPRequest("GET", "/api", raw, nil, nil)
 	require.NoError(t, err)
@@ -111,8 +138,7 @@ func TestBuildAPIGatewayQueryString_MultiValuePreferred(t *testing.T) {
 }
 
 func TestBuildAPIGatewayQueryString_Empty(t *testing.T) {
-	req := events.APIGatewayProxyRequest{}
-	assert.Equal(t, "", buildAPIGatewayQueryString(req))
+	assert.Equal(t, "", buildAPIGatewayQueryString(lambdaHTTPEvent{}))
 }
 
 func TestDecodeLambdaBody_PlainText(t *testing.T) {
@@ -136,43 +162,43 @@ func TestDecodeLambdaBody_InvalidBase64(t *testing.T) {
 }
 
 func TestBuildAPIGatewayHeaders_SingleValue(t *testing.T) {
-	req := events.APIGatewayProxyRequest{
+	evt := lambdaHTTPEvent{
 		Headers: map[string]string{"Content-Type": "application/json"},
 	}
 
-	header := buildAPIGatewayHeaders(req)
+	header := buildAPIGatewayHeaders(evt)
 	assert.Equal(t, "application/json", header.Get("Content-Type"))
 }
 
 func TestBuildAPIGatewayHeaders_MultiValuePreferred(t *testing.T) {
-	req := events.APIGatewayProxyRequest{
+	evt := lambdaHTTPEvent{
 		Headers: map[string]string{"X-Custom": "single"},
 		MultiValueHeaders: map[string][]string{
 			"X-Custom": {"a", "b"},
 		},
 	}
 
-	header := buildAPIGatewayHeaders(req)
+	header := buildAPIGatewayHeaders(evt)
 	assert.Equal(t, []string{"a", "b"}, header.Values("X-Custom"))
 }
 
 func TestBuildFunctionURLHeaders_FoldsCookies(t *testing.T) {
-	req := events.LambdaFunctionURLRequest{
+	evt := lambdaHTTPEvent{
 		Headers: map[string]string{"Content-Type": "text/plain"},
 		Cookies: []string{"session=abc", "theme=dark"},
 	}
 
-	header := buildFunctionURLHeaders(req)
+	header := buildFunctionURLHeaders(evt)
 	assert.Equal(t, "text/plain", header.Get("Content-Type"))
 	assert.Equal(t, "session=abc; theme=dark", header.Get("Cookie"))
 }
 
 func TestBuildFunctionURLHeaders_NoCookies(t *testing.T) {
-	req := events.LambdaFunctionURLRequest{
+	evt := lambdaHTTPEvent{
 		Headers: map[string]string{"Accept": "application/json"},
 	}
 
-	header := buildFunctionURLHeaders(req)
+	header := buildFunctionURLHeaders(evt)
 	assert.Equal(t, "application/json", header.Get("Accept"))
 	assert.Empty(t, header.Get("Cookie"))
 }
@@ -180,12 +206,12 @@ func TestBuildFunctionURLHeaders_NoCookies(t *testing.T) {
 // TestFunctionURLCookiesReadableAsCookie verifies the folded Cookie header is
 // parseable by the standard library, so downstream cookie access works.
 func TestFunctionURLCookiesReadableAsCookie(t *testing.T) {
-	req := events.LambdaFunctionURLRequest{
+	evt := lambdaHTTPEvent{
 		RawPath: "/api",
 		Cookies: []string{"session=abc", "theme=dark"},
 	}
 
-	httpReq, err := convertLambdaRequestToHTTPRequest(req.RequestContext.HTTP.Method, req.RawPath, req.RawQueryString, buildFunctionURLHeaders(req), nil)
+	httpReq, err := convertLambdaRequestToHTTPRequest("GET", evt.RawPath, evt.RawQueryString, buildFunctionURLHeaders(evt), nil)
 	require.NoError(t, err)
 
 	c, err := httpReq.Cookie("session")
@@ -196,14 +222,16 @@ func TestFunctionURLCookiesReadableAsCookie(t *testing.T) {
 	assert.Equal(t, "dark", c.Value)
 }
 
-func TestHandleAPIGatewayProxyRequest_PreservesQueryParams(t *testing.T) {
-	req := events.APIGatewayProxyRequest{
+// TestAPIGatewayQueryParamsReachRequest exercises the v1 assembly: query params
+// from the event reach the http.Request.
+func TestAPIGatewayQueryParamsReachRequest(t *testing.T) {
+	evt := lambdaHTTPEvent{
 		HTTPMethod:            "GET",
 		Path:                  "/api/endpoint",
 		QueryStringParameters: map[string]string{"foo": "bar"},
 	}
 
-	httpReq, err := convertLambdaRequestToHTTPRequest(req.HTTPMethod, req.Path, buildAPIGatewayQueryString(req), buildAPIGatewayHeaders(req), []byte(req.Body))
+	httpReq, err := convertLambdaRequestToHTTPRequest(evt.HTTPMethod, evt.Path, buildAPIGatewayQueryString(evt), buildAPIGatewayHeaders(evt), []byte(evt.Body))
 	require.NoError(t, err)
 	assert.Equal(t, "bar", httpReq.URL.Query().Get("foo"))
 }
@@ -211,16 +239,16 @@ func TestHandleAPIGatewayProxyRequest_PreservesQueryParams(t *testing.T) {
 // TestFormURLEncodedBodyParses exercises the full path a form POST takes: the
 // body and Content-Type header must survive conversion so ParseForm works.
 func TestFormURLEncodedBodyParses(t *testing.T) {
-	req := events.APIGatewayProxyRequest{
+	evt := lambdaHTTPEvent{
 		HTTPMethod: "POST",
 		Path:       "/submit",
 		Headers:    map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
 		Body:       "name=alice&role=admin",
 	}
 
-	body, err := decodeLambdaBody(req.Body, req.IsBase64Encoded)
+	body, err := decodeLambdaBody(evt.Body, evt.IsBase64Encoded)
 	require.NoError(t, err)
-	httpReq, err := convertLambdaRequestToHTTPRequest(req.HTTPMethod, req.Path, buildAPIGatewayQueryString(req), buildAPIGatewayHeaders(req), body)
+	httpReq, err := convertLambdaRequestToHTTPRequest(evt.HTTPMethod, evt.Path, buildAPIGatewayQueryString(evt), buildAPIGatewayHeaders(evt), body)
 	require.NoError(t, err)
 
 	require.NoError(t, httpReq.ParseForm())
@@ -231,7 +259,7 @@ func TestFormURLEncodedBodyParses(t *testing.T) {
 // TestBase64FormBodyParses verifies a base64-encoded form body (as API Gateway
 // delivers binary/opaque payloads) is decoded before form parsing.
 func TestBase64FormBodyParses(t *testing.T) {
-	req := events.APIGatewayProxyRequest{
+	evt := lambdaHTTPEvent{
 		HTTPMethod:      "POST",
 		Path:            "/submit",
 		Headers:         map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
@@ -239,9 +267,9 @@ func TestBase64FormBodyParses(t *testing.T) {
 		IsBase64Encoded: true,
 	}
 
-	body, err := decodeLambdaBody(req.Body, req.IsBase64Encoded)
+	body, err := decodeLambdaBody(evt.Body, evt.IsBase64Encoded)
 	require.NoError(t, err)
-	httpReq, err := convertLambdaRequestToHTTPRequest(req.HTTPMethod, req.Path, buildAPIGatewayQueryString(req), buildAPIGatewayHeaders(req), body)
+	httpReq, err := convertLambdaRequestToHTTPRequest(evt.HTTPMethod, evt.Path, buildAPIGatewayQueryString(evt), buildAPIGatewayHeaders(evt), body)
 	require.NoError(t, err)
 
 	require.NoError(t, httpReq.ParseForm())
@@ -249,13 +277,15 @@ func TestBase64FormBodyParses(t *testing.T) {
 	assert.Equal(t, "user", httpReq.PostFormValue("role"))
 }
 
-func TestHandleLambdaFunctionURLRequest_PreservesQueryParams(t *testing.T) {
-	req := events.LambdaFunctionURLRequest{
+// TestFunctionURLQueryParamsReachRequest exercises the v2 assembly: the raw
+// query string reaches the http.Request.
+func TestFunctionURLQueryParamsReachRequest(t *testing.T) {
+	evt := lambdaHTTPEvent{
 		RawPath:        "/api/endpoint",
 		RawQueryString: "foo=bar&baz=qux",
 	}
 
-	httpReq, err := convertLambdaRequestToHTTPRequest(req.RequestContext.HTTP.Method, req.RawPath, req.RawQueryString, buildFunctionURLHeaders(req), []byte(req.Body))
+	httpReq, err := convertLambdaRequestToHTTPRequest("GET", evt.RawPath, evt.RawQueryString, buildFunctionURLHeaders(evt), []byte(evt.Body))
 	require.NoError(t, err)
 	assert.Equal(t, "bar", httpReq.URL.Query().Get("foo"))
 	assert.Equal(t, "qux", httpReq.URL.Query().Get("baz"))

--- a/internal/adapter/awslambda/awslambda_test.go
+++ b/internal/adapter/awslambda/awslambda_test.go
@@ -1,0 +1,104 @@
+package awslambda
+
+import (
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertLambdaRequestToHTTPRequest_WithQuery(t *testing.T) {
+	httpReq, err := convertLambdaRequestToHTTPRequest("GET", "/api/endpoint", "foo=bar&baz=qux", nil, "")
+	require.NoError(t, err)
+
+	assert.Equal(t, "/api/endpoint", httpReq.URL.Path)
+	assert.Equal(t, "foo=bar&baz=qux", httpReq.URL.RawQuery)
+	assert.Equal(t, "bar", httpReq.URL.Query().Get("foo"))
+	assert.Equal(t, "qux", httpReq.URL.Query().Get("baz"))
+	assert.Equal(t, "/api/endpoint?foo=bar&baz=qux", httpReq.URL.RequestURI())
+}
+
+func TestConvertLambdaRequestToHTTPRequest_WithoutQuery(t *testing.T) {
+	httpReq, err := convertLambdaRequestToHTTPRequest("GET", "/api/endpoint", "", nil, "")
+	require.NoError(t, err)
+
+	assert.Equal(t, "/api/endpoint", httpReq.URL.Path)
+	assert.Equal(t, "", httpReq.URL.RawQuery)
+	assert.Empty(t, httpReq.URL.Query())
+}
+
+func TestConvertLambdaRequestToHTTPRequest_EncodedQueryRoundTrips(t *testing.T) {
+	// A raw query with an encoded space and ampersand should decode correctly.
+	httpReq, err := convertLambdaRequestToHTTPRequest("GET", "/search", "q=hello+world%26more", nil, "")
+	require.NoError(t, err)
+
+	assert.Equal(t, "hello world&more", httpReq.URL.Query().Get("q"))
+}
+
+func TestBuildAPIGatewayQueryString_SingleValue(t *testing.T) {
+	req := events.APIGatewayProxyRequest{
+		QueryStringParameters: map[string]string{"foo": "bar"},
+	}
+
+	raw := buildAPIGatewayQueryString(req)
+	assert.Equal(t, "foo=bar", raw)
+}
+
+func TestBuildAPIGatewayQueryString_EncodesSpecialCharacters(t *testing.T) {
+	// The event delivers already-decoded values; the reconstructed query string
+	// must re-encode them so they round-trip through url.Query().
+	req := events.APIGatewayProxyRequest{
+		QueryStringParameters: map[string]string{"q": "hello world&more"},
+	}
+
+	raw := buildAPIGatewayQueryString(req)
+
+	httpReq, err := convertLambdaRequestToHTTPRequest("GET", "/search", raw, nil, "")
+	require.NoError(t, err)
+	assert.Equal(t, "hello world&more", httpReq.URL.Query().Get("q"))
+}
+
+func TestBuildAPIGatewayQueryString_MultiValuePreferred(t *testing.T) {
+	req := events.APIGatewayProxyRequest{
+		QueryStringParameters: map[string]string{"foo": "b"},
+		MultiValueQueryStringParameters: map[string][]string{
+			"foo": {"a", "b"},
+		},
+	}
+
+	raw := buildAPIGatewayQueryString(req)
+
+	httpReq, err := convertLambdaRequestToHTTPRequest("GET", "/api", raw, nil, "")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b"}, httpReq.URL.Query()["foo"])
+}
+
+func TestBuildAPIGatewayQueryString_Empty(t *testing.T) {
+	req := events.APIGatewayProxyRequest{}
+	assert.Equal(t, "", buildAPIGatewayQueryString(req))
+}
+
+func TestHandleAPIGatewayProxyRequest_PreservesQueryParams(t *testing.T) {
+	req := events.APIGatewayProxyRequest{
+		HTTPMethod:            "GET",
+		Path:                  "/api/endpoint",
+		QueryStringParameters: map[string]string{"foo": "bar"},
+	}
+
+	httpReq, err := convertLambdaRequestToHTTPRequest(req.HTTPMethod, req.Path, buildAPIGatewayQueryString(req), req.Headers, req.Body)
+	require.NoError(t, err)
+	assert.Equal(t, "bar", httpReq.URL.Query().Get("foo"))
+}
+
+func TestHandleLambdaFunctionURLRequest_PreservesQueryParams(t *testing.T) {
+	req := events.LambdaFunctionURLRequest{
+		RawPath:        "/api/endpoint",
+		RawQueryString: "foo=bar&baz=qux",
+	}
+
+	httpReq, err := convertLambdaRequestToHTTPRequest(req.RequestContext.HTTP.Method, req.RawPath, req.RawQueryString, req.Headers, req.Body)
+	require.NoError(t, err)
+	assert.Equal(t, "bar", httpReq.URL.Query().Get("foo"))
+	assert.Equal(t, "qux", httpReq.URL.Query().Get("baz"))
+}


### PR DESCRIPTION
Preserve query parameters, request body, headers and cookies when translating AWS Lambda events into internal HTTP requests.

Fixes #96

## Summary

- Query parameters from API Gateway (v1) and Function URL / HTTP API (v2) events were dropped, so `queryParams` matching never matched, `context.request.queryParams` was always empty, and `request.uri` carried no query string.
- Reconstruct the query string onto the request URL: use v2's already-encoded `RawQueryString` directly, and re-encode v1's decoded `QueryStringParameters` (preferring `MultiValueQueryStringParameters` so repeated keys survive).
- Base64-decode request bodies flagged `IsBase64Encoded`, so binary and multipart payloads are no longer corrupted before body matching and form parsing.
- Fold v2 cookies (delivered in a separate `Cookies` array) back into a single `Cookie` header, and prefer v1 `MultiValueHeaders` so repeated request headers are preserved.
- Add unit tests covering query round-tripping, plain and base64 bodies, single/multi-value headers, cookie folding, and form-body parsing.

## Implementation details

- Form parameters need no dedicated handling: once the body and `Content-Type` header survive conversion, Go's `ParseForm`/`ParseMultipartForm` derive them downstream — they were failing only as a symptom of the body and header bugs (notably multipart uploads, which arrive base64-encoded).
- `convertLambdaRequestToHTTPRequest` now takes the decoded body (`[]byte`) and an assembled `http.Header`, so body decoding, header merging and cookie folding funnel through one place per event type. The body base64-decoding mirrors the base64 *encoding* already applied to binary responses.