### PR TITLE
Fix/OIDC with reverse proxy

### DIFF
--- a/external/plugins/oidc-server/auth.go
+++ b/external/plugins/oidc-server/auth.go
@@ -167,6 +167,11 @@ func (o *OIDCServer) renderLoginForm(sessionID, clientID string, errorMsg ...str
 		errorMessage = errorMsg[0]
 	}
 
+	serverBase := ""
+	if parsed, err := url.Parse(o.serverURL); err == nil {
+		serverBase = strings.TrimRight(parsed.Path, "/")
+	}
+
 	data := struct {
 		SessionID  string
 		ClientID   string
@@ -175,7 +180,7 @@ func (o *OIDCServer) renderLoginForm(sessionID, clientID string, errorMsg ...str
 	}{
 		SessionID:  sessionID,
 		ClientID:   clientID,
-		PathPrefix: o.pathPrefix,
+		PathPrefix: serverBase + o.pathPrefix,
 		Error:      errorMessage,
 	}
 

--- a/external/plugins/oidc-server/auth.go
+++ b/external/plugins/oidc-server/auth.go
@@ -175,12 +175,14 @@ func (o *OIDCServer) renderLoginForm(sessionID, clientID string, errorMsg ...str
 	data := struct {
 		SessionID  string
 		ClientID   string
+		ServerBase string
 		PathPrefix string
 		Error      string
 	}{
 		SessionID:  sessionID,
 		ClientID:   clientID,
-		PathPrefix: serverBase + o.pathPrefix,
+		ServerBase: serverBase,
+		PathPrefix: o.pathPrefix,
 		Error:      errorMessage,
 	}
 

--- a/external/plugins/oidc-server/auth_test.go
+++ b/external/plugins/oidc-server/auth_test.go
@@ -380,6 +380,32 @@ func TestOIDCServer_handleAuthorizePost(t *testing.T) {
 	}
 }
 
+func TestOIDCServer_renderLoginForm_withServerBasePath(t *testing.T) {
+	config := getDefaultConfig()
+	server := &OIDCServer{
+		logger: hclog.New(&hclog.LoggerOptions{
+			Level:  hclog.Off,
+			Output: nil,
+		}),
+		config:     config,
+		serverURL:  "http://localhost:8080/myapp",
+		pathPrefix: "/oidc",
+		sessions:   make(map[string]*AuthSession),
+		codes:      make(map[string]*AuthCode),
+		tokens:     make(map[string]*AccessToken),
+		jwtSecret:  []byte("test-secret-key-32-bytes-long!"),
+	}
+
+	resp := server.renderLoginForm("test-session", "test-client")
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected status 200, got %d", resp.StatusCode)
+	}
+	body := string(resp.Body)
+	if !strings.Contains(body, `action="/myapp/oidc/authorize"`) {
+		t.Errorf("Expected form action to include server base path, got body: %s", body)
+	}
+}
+
 func TestOIDCServer_renderLoginForm(t *testing.T) {
 	server := createTestOIDCServerForAuth()
 
@@ -399,6 +425,7 @@ func TestOIDCServer_renderLoginForm(t *testing.T) {
 				return strings.Contains(body, "test-session") &&
 					strings.Contains(body, "test-client") &&
 					strings.Contains(body, "Sign In") &&
+					strings.Contains(body, `action="/oidc/authorize"`) &&
 					!strings.Contains(body, "class=\"error\"")
 			},
 		},

--- a/external/plugins/oidc-server/templates/login.html
+++ b/external/plugins/oidc-server/templates/login.html
@@ -109,7 +109,7 @@
         <div class="error">{{.Error}}</div>
         {{end}}
         
-        <form method="POST" action="{{.PathPrefix}}/authorize">
+        <form method="POST" action="{{.ServerBase}}{{.PathPrefix}}/authorize">
             <input type="hidden" name="session_id" value="{{.SessionID}}">
             
             <div class="form-group">


### PR DESCRIPTION
# Fix: OIDC login form POST action ignores server base path

## Summary

The login page for the OIDC plugin doesn't respect the path component of `IMPOSTER_SERVER_URL`, so when attempting to log in via the hosted UI, the login POST is targeted at `/oidc` regardless of the path.

For example, when Imposter is deployed behind a reverse proxy under a path prefix — for example `https://example.com/myapp`, with `IMPOSTER_SERVER_URL` set correctly, the login form rendered by the OIDC plugin uses only the OIDC path prefix (e.g. `/oidc`), ignoring any path component in `IMPOSTER_SERVER_URL`:

```html
<form method="POST" action="/oidc/authorize">
```

When a user submits the login form, the browser resolves this as an absolute path and POSTs to `/oidc/authorize`, which doesn't line up with the response handler, as it should be `/myapp/oidc/authorize`.

I believe the rest of the components of the OIDC plugin work correctly, this is the only issue I'm aware of.

## What changes

In `renderLoginForm` (`external/plugins/oidc-server/auth.go`), the server URL is now parsed to extract its path component, which is prepended to the OIDC path prefix before passing it to the template.

This produces the correct form action without any changes to the template itself:

```html
<!-- With base path (e.g. IMPOSTER_SERVER_URL=http://localhost:8080/myapp) -->
<form method="POST" action="/myapp/oidc/authorize">
```

When `IMPOSTER_SERVER_URL` has no path component the behaviour is identical to before.

## Verification

I had been testing this behind a Caddy proxy with config:

```
:80 {
  handle_path /oidc-stub/* {
    reverse_proxy localhost:8080
  }
}
```

But this is also verifiable with a minimal Go proxy (navigating to http://localhost:9090/myapp/oidc/authorize?client_id=webapp&redirect_uri=http://localhost:3000/callback&response_type=code&scope=openid):

```go
package main

import (
	"net/http"
	"net/http/httputil"
	"net/url"
	"strings"
)

func main() {
	target, _ := url.Parse("http://localhost:8080")
	proxy := httputil.NewSingleHostReverseProxy(target)
	proxy.Director = func(req *http.Request) {
		req.URL.Scheme = target.Scheme
		req.URL.Host = target.Host
		req.Host = target.Host
		req.URL.Path = strings.TrimPrefix(req.URL.Path, "/myapp")
		if req.URL.Path == "" {
			req.URL.Path = "/"
		}
	}
	http.ListenAndServe(":9090", proxy)
}
```
