### PR TITLE
feat: stream HTTP responses (SSE/chunked) and generalise scheduled push to core

### DIFF
--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -1,0 +1,91 @@
+# Streaming responses
+
+By default a resource produces a single response that is buffered and written in
+one go. Setting `stream: true` on a resource instead delivers its output
+**incrementally**: each part is written and flushed to the client as it is
+produced, over a chunked (`Transfer-Encoding: chunked`) HTTP response.
+
+This drives Server-Sent Events (SSE), newline-delimited JSON (NDJSON), and any
+other chunked format — for example standing in for an "OpenAI compatible"
+streaming chat completion.
+
+Streaming is supported by the plugins that serve responses through the shared
+request pipeline: `rest` and `openapi`.
+
+## A fixed sequence of chunks
+
+List the parts under `responses`. Each is processed like a normal response
+(`file`/`content`, `template`, `headers`, `statusCode`) and flushed separately.
+A per-part `delay` paces the stream.
+
+```yaml
+plugin: rest
+resources:
+  - path: /v1/chat/completions
+    method: POST
+    stream: true
+    responses:
+      - content: "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n"
+        headers:
+          Content-Type: text/event-stream
+        delay: { exact: 50 }
+      - content: "data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}\n\n"
+        delay: { exact: 50 }
+      - content: "data: [DONE]\n\n"
+```
+
+The status line and headers are taken from the first part, so set the
+`Content-Type` (e.g. `text/event-stream`) there. Write the SSE framing
+(`data: ...\n\n`) into the content yourself — the engine streams the bytes
+as-is.
+
+`responses` (the plural, multi-part form) requires `stream: true`. A single
+`response` block is the normal, buffered form unless you also set `stream: true`.
+
+## Open-ended server push
+
+A `schedule` on a streamed resource keeps the connection open and pushes further
+responses on a timer — an SSE keepalive, progress updates, live data. It reuses
+the same schedule triggers as [top-level and websocket schedules](#see-also)
+(`every` or `cron`, with an optional `limit`).
+
+```yaml
+plugin: rest
+resources:
+  - path: /events
+    method: GET
+    stream: true
+    response:
+      content: ": stream open\n\n"
+      headers:
+        Content-Type: text/event-stream
+    schedule:
+      - name: keepalive
+        every: 1s
+        limit: 10          # omit to push for as long as the client stays connected
+        response:
+          template: true
+          content: "data: {\"type\":\"ping\",\"at\":\"${datetime.now.iso8601_datetime}\"}\n\n"
+```
+
+The request handler holds the response open while the schedules run. It returns
+— ending the response — once every schedule reaches its `limit`, or as soon as
+the client disconnects. As with all schedules, set a `limit` (or the global
+`IMPOSTER_SCHEDULE_LIMIT`) unless the stream genuinely should run for as long as
+the client is connected.
+
+## Notes and limits
+
+- **Flushable connection required.** Streaming needs a long-lived, flushable
+  HTTP connection. Under the AWS Lambda adapter — which buffers a single
+  response — the parts are concatenated into one body instead, and schedules
+  (which need an open connection) are skipped with a warning.
+- **Content type inference.** As with any response, if no `Content-Type` is set
+  it is inferred from the response file extension, falling back to JSON.
+
+## See also
+
+- [Rate limiting](./rate_limiting.md)
+- The `examples/rest/sse-streaming` example
+- The websocket plugin, whose multiple-response and scheduled-frame sending
+  shares the same core (`internal/emit`).

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -82,6 +82,10 @@ the client is connected.
   (which need an open connection) are skipped with a warning.
 - **Content type inference.** As with any response, if no `Content-Type` is set
   it is inferred from the response file extension, falling back to JSON.
+- **Websocket is always streaming.** A websocket connection is inherently a
+  multi-frame stream, so `stream` is implicit there: setting `stream: true` is
+  redundant but accepted, while an explicit `stream: false` is rejected at
+  startup, since the plugin cannot honour it.
 
 ## See also
 

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -6,8 +6,7 @@ one go. Setting `stream: true` on a resource instead delivers its output
 produced, over a chunked (`Transfer-Encoding: chunked`) HTTP response.
 
 This drives Server-Sent Events (SSE), newline-delimited JSON (NDJSON), and any
-other chunked format — for example standing in for an "OpenAI compatible"
-streaming chat completion.
+other chunked format.
 
 Streaming is supported by the plugins that serve responses through the shared
 request pipeline: `rest` and `openapi`.
@@ -21,18 +20,21 @@ A per-part `delay` paces the stream.
 ```yaml
 plugin: rest
 resources:
-  - path: /v1/chat/completions
-    method: POST
+  - path: /updates
+    method: GET
     stream: true
     responses:
-      - content: "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n"
+      - content: "data: working\n\n"
         headers:
           Content-Type: text/event-stream
-        delay: { exact: 50 }
-      - content: "data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}\n\n"
-        delay: { exact: 50 }
-      - content: "data: [DONE]\n\n"
+        delay: { exact: 500 }
+      - content: "data: still working\n\n"
+        delay: { exact: 500 }
+      - content: "data: done\n\n"
 ```
+
+A client reading this receives three `data:` events half a second apart, rather
+than all at once at the end.
 
 The status line and headers are taken from the first part, so set the
 `Content-Type` (e.g. `text/event-stream`) there. Write the SSE framing

--- a/examples/rest/sse-streaming/README.md
+++ b/examples/rest/sse-streaming/README.md
@@ -1,0 +1,52 @@
+# Streaming example: Server-Sent Events and scheduled push
+
+Demonstrates incremental HTTP streaming with `stream: true`. Instead of
+buffering a single response body, the engine writes and flushes each part to
+the client as it is produced:
+
+- **A fixed sequence** — the `responses` list. Each block is flushed
+  separately, paced by its `delay`, so an OpenAI-style chat completion arrives
+  token-by-token and ends with the `[DONE]` sentinel.
+- **Open-ended push** — a `schedule` on a streamed resource pushes further
+  events over the open connection on a timer, until its `limit` is reached or
+  the client disconnects.
+
+Both are the same core capability the websocket plugin uses to send multiple
+and scheduled frames, generalised to HTTP.
+
+## Run
+
+```bash
+imposter ./examples/rest/sse-streaming
+```
+
+## Try it
+
+A streamed chat completion (use `-N` so curl doesn't buffer):
+
+```bash
+curl -N -X POST http://localhost:8080/v1/chat/completions \
+  -H 'Content-Type: application/json' -d '{"stream":true}'
+```
+
+You'll see each `data:` chunk arrive ~50 ms apart, ending with `data: [DONE]`.
+
+An open-ended event stream with a keepalive pushed once a second (stops after
+10, or when you press Ctrl-C):
+
+```bash
+curl -N http://localhost:8080/events
+```
+
+## How it works
+
+`stream: true` opts the resource into incremental delivery. The response is sent
+with `Transfer-Encoding: chunked` and each block is flushed as it is written.
+Set the `Content-Type` (e.g. `text/event-stream`) on the first block. Write the
+SSE framing (`data: ...\n\n`) into the content yourself — the engine streams the
+bytes as-is, so the same mechanism also serves NDJSON or any chunked format.
+
+> [!NOTE]
+> Streaming needs a long-lived, flushable connection. Under the AWS Lambda
+> adapter the blocks are concatenated into a single buffered response instead,
+> and schedules (which require an open connection) are skipped.

--- a/examples/rest/sse-streaming/imposter-config.yaml
+++ b/examples/rest/sse-streaming/imposter-config.yaml
@@ -1,0 +1,43 @@
+# Demonstrates streaming HTTP responses with `stream: true`. Each block in
+# 'responses' is written and flushed to the client separately, paced by its
+# 'delay', so the client receives Server-Sent Events incrementally rather than
+# one buffered body. A 'schedule' on a streamed resource pushes further events
+# over the open connection until its limit is reached or the client disconnects.
+plugin: rest
+
+resources:
+  # An OpenAI-style chat completion stream: a fixed sequence of SSE chunks,
+  # ending with the conventional [DONE] sentinel.
+  - path: /v1/chat/completions
+    method: POST
+    stream: true
+    responses:
+      - content: "data: {\"choices\":[{\"delta\":{\"role\":\"assistant\"}}]}\n\n"
+        headers:
+          Content-Type: text/event-stream
+        delay: { exact: 50 }
+      - content: "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n"
+        delay: { exact: 50 }
+      - content: "data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}\n\n"
+        delay: { exact: 50 }
+      - content: "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n"
+        delay: { exact: 50 }
+      - content: "data: [DONE]\n\n"
+
+  # An open-ended event stream: an initial comment to open the stream, then a
+  # keepalive pushed every second by a request-scoped schedule. It stops after
+  # 10 ticks, or as soon as the client disconnects.
+  - path: /events
+    method: GET
+    stream: true
+    response:
+      content: ": stream open\n\n"
+      headers:
+        Content-Type: text/event-stream
+    schedule:
+      - name: keepalive
+        every: 1s
+        limit: 10
+        response:
+          template: true
+          content: "data: {\"type\":\"ping\",\"at\":\"${datetime.now.iso8601_datetime}\"}\n\n"

--- a/internal/config/model.go
+++ b/internal/config/model.go
@@ -251,7 +251,7 @@ type BaseResource struct {
 	Steps            []Step             `yaml:"steps,omitempty"`
 	Response         *Response          `yaml:"response,omitempty"`
 	Responses        []Response         `yaml:"responses,omitempty"`
-	Stream           bool               `yaml:"stream,omitempty"` // stream 'responses'/'schedule' output to the client incrementally (HTTP: Server-Sent Events / chunked)
+	Stream           *bool              `yaml:"stream,omitempty"` // stream 'responses'/'schedule' output incrementally (HTTP: SSE/chunked). Tri-state: unset = plugin default (buffered for HTTP, always-on for websocket); the websocket plugin rejects an explicit false
 	Concurrency      []ConcurrencyLimit `yaml:"concurrency,omitempty"`
 	Log              string             `yaml:"log,omitempty"`
 	Passthrough      string             `yaml:"passthrough,omitempty"`
@@ -268,6 +268,13 @@ type BaseResource struct {
 // to a 'responses' list with one element.
 func (r *BaseResource) EffectiveResponses() []Response {
 	return effectiveResponses(r.Response, r.Responses)
+}
+
+// StreamEnabled reports whether this resource has explicitly opted into
+// incremental streaming ('stream: true'). It is false when unset or explicitly
+// false. Websocket connections stream by nature and do not consult this.
+func (r *BaseResource) StreamEnabled() bool {
+	return r.Stream != nil && *r.Stream
 }
 
 // Schedule defines a time-driven trigger. At the top level of a config it

--- a/internal/config/model.go
+++ b/internal/config/model.go
@@ -251,6 +251,7 @@ type BaseResource struct {
 	Steps            []Step             `yaml:"steps,omitempty"`
 	Response         *Response          `yaml:"response,omitempty"`
 	Responses        []Response         `yaml:"responses,omitempty"`
+	Stream           bool               `yaml:"stream,omitempty"` // stream 'responses'/'schedule' output to the client incrementally (HTTP: Server-Sent Events / chunked)
 	Concurrency      []ConcurrencyLimit `yaml:"concurrency,omitempty"`
 	Log              string             `yaml:"log,omitempty"`
 	Passthrough      string             `yaml:"passthrough,omitempty"`

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -81,13 +81,11 @@ func validateWebSocketFields(cfg *Config, res *Resource) error {
 		if res.On != "" {
 			return fmt.Errorf("resource (path %q) declares 'on', which is only supported by the websocket plugin", res.Path)
 		}
-		if len(res.Responses) > 0 {
-			return fmt.Errorf("resource (path %q) declares 'responses', which is only supported by the websocket plugin", res.Path)
-		}
-		if len(res.Schedule) > 0 {
-			return fmt.Errorf("resource (path %q) declares 'schedule', which is only supported by the websocket plugin", res.Path)
-		}
-		return nil
+		return validateStreamingFields(cfg, res)
+	}
+
+	if res.Stream {
+		logger.Warnf("resource (path %q) declares 'stream', which has no effect for websocket resources; websocket responses are always sent as frames", res.Path)
 	}
 
 	switch res.On {
@@ -112,8 +110,51 @@ func validateWebSocketFields(cfg *Config, res *Resource) error {
 		logger.Warnf("resource (path %q) declares 'method', which has no effect for websocket resources", res.Path)
 	}
 
-	for i := range res.Schedule {
-		sched := &res.Schedule[i]
+	return validateScheduleEntries(res.Schedule)
+}
+
+// streamingPlugins are the plugins that serve responses through the shared
+// pipeline and therefore support incremental streaming ('stream: true').
+var streamingPlugins = map[string]bool{"rest": true, "openapi": true}
+
+// validateStreamingFields checks the 'stream', 'responses' and 'schedule'
+// fields on a non-websocket (HTTP) resource. Streaming is only supported by
+// the plugins that serve responses through the shared pipeline.
+func validateStreamingFields(cfg *Config, res *Resource) error {
+	if !streamingPlugins[cfg.Plugin] {
+		if res.Stream {
+			return fmt.Errorf("resource (path %q) declares 'stream', which is not supported by the %q plugin", res.Path, cfg.Plugin)
+		}
+		if len(res.Responses) > 0 {
+			return fmt.Errorf("resource (path %q) declares 'responses', which is not supported by the %q plugin", res.Path, cfg.Plugin)
+		}
+		if len(res.Schedule) > 0 {
+			return fmt.Errorf("resource (path %q) declares 'schedule', which is not supported by the %q plugin", res.Path, cfg.Plugin)
+		}
+		return nil
+	}
+
+	// A 'responses' list is streamed one flushed chunk at a time; requiring the
+	// explicit opt-in keeps the intent clear and leaves room to give multiple
+	// buffered responses a different meaning later.
+	if len(res.Responses) > 0 && !res.Stream {
+		return fmt.Errorf("resource (path %q) declares multiple 'responses' without 'stream: true'; set 'stream: true' to send them as a stream, or use a single 'response'", res.Path)
+	}
+	if len(res.Schedule) > 0 && !res.Stream {
+		return fmt.Errorf("resource (path %q) declares a 'schedule' without 'stream: true'; scheduled server-push requires a stream", res.Path)
+	}
+	if res.Stream && res.Response == nil && len(res.Responses) == 0 && len(res.Schedule) == 0 {
+		return fmt.Errorf("resource (path %q) declares 'stream: true' but has no 'response', 'responses' or 'schedule' to stream", res.Path)
+	}
+
+	return validateScheduleEntries(res.Schedule)
+}
+
+// validateScheduleEntries validates a set of schedule entries' triggers and
+// payloads. Shared by websocket and HTTP streaming resources.
+func validateScheduleEntries(schedules []Schedule) error {
+	for i := range schedules {
+		sched := &schedules[i]
 		desc := scheduleDesc(sched, i)
 		if err := validateScheduleTrigger(sched, desc); err != nil {
 			return err
@@ -125,7 +166,6 @@ func validateWebSocketFields(cfg *Config, res *Resource) error {
 			return fmt.Errorf("%s must declare a response or at least one step", desc)
 		}
 	}
-
 	return nil
 }
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -84,8 +84,12 @@ func validateWebSocketFields(cfg *Config, res *Resource) error {
 		return validateStreamingFields(cfg, res)
 	}
 
-	if res.Stream {
-		logger.Warnf("resource (path %q) declares 'stream', which has no effect for websocket resources; websocket responses are always sent as frames", res.Path)
+	// A websocket connection is inherently a streaming, multi-frame transport,
+	// so 'stream' is implicitly true and setting it is redundant-but-consistent.
+	// An explicit 'stream: false', however, asserts something the plugin cannot
+	// honour, so reject it to catch the misunderstanding at startup.
+	if res.Stream != nil && !*res.Stream {
+		return fmt.Errorf("resource (path %q) declares 'stream: false', but the websocket plugin always streams responses as frames; remove it", res.Path)
 	}
 
 	switch res.On {
@@ -121,9 +125,11 @@ var streamingPlugins = map[string]bool{"rest": true, "openapi": true}
 // fields on a non-websocket (HTTP) resource. Streaming is only supported by
 // the plugins that serve responses through the shared pipeline.
 func validateStreamingFields(cfg *Config, res *Resource) error {
+	streaming := res.StreamEnabled()
+
 	if !streamingPlugins[cfg.Plugin] {
-		if res.Stream {
-			return fmt.Errorf("resource (path %q) declares 'stream', which is not supported by the %q plugin", res.Path, cfg.Plugin)
+		if streaming {
+			return fmt.Errorf("resource (path %q) declares 'stream: true', which is not supported by the %q plugin", res.Path, cfg.Plugin)
 		}
 		if len(res.Responses) > 0 {
 			return fmt.Errorf("resource (path %q) declares 'responses', which is not supported by the %q plugin", res.Path, cfg.Plugin)
@@ -137,13 +143,13 @@ func validateStreamingFields(cfg *Config, res *Resource) error {
 	// A 'responses' list is streamed one flushed chunk at a time; requiring the
 	// explicit opt-in keeps the intent clear and leaves room to give multiple
 	// buffered responses a different meaning later.
-	if len(res.Responses) > 0 && !res.Stream {
+	if len(res.Responses) > 0 && !streaming {
 		return fmt.Errorf("resource (path %q) declares multiple 'responses' without 'stream: true'; set 'stream: true' to send them as a stream, or use a single 'response'", res.Path)
 	}
-	if len(res.Schedule) > 0 && !res.Stream {
+	if len(res.Schedule) > 0 && !streaming {
 		return fmt.Errorf("resource (path %q) declares a 'schedule' without 'stream: true'; scheduled server-push requires a stream", res.Path)
 	}
-	if res.Stream && res.Response == nil && len(res.Responses) == 0 && len(res.Schedule) == 0 {
+	if streaming && res.Response == nil && len(res.Responses) == 0 && len(res.Schedule) == 0 {
 		return fmt.Errorf("resource (path %q) declares 'stream: true' but has no 'response', 'responses' or 'schedule' to stream", res.Path)
 	}
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -140,9 +140,8 @@ func validateStreamingFields(cfg *Config, res *Resource) error {
 		return nil
 	}
 
-	// A 'responses' list is streamed one flushed chunk at a time; requiring the
-	// explicit opt-in keeps the intent clear and leaves room to give multiple
-	// buffered responses a different meaning later.
+	// A 'responses' list is streamed one flushed chunk at a time; the explicit
+	// opt-in keeps that intent unambiguous.
 	if len(res.Responses) > 0 && !streaming {
 		return fmt.Errorf("resource (path %q) declares multiple 'responses' without 'stream: true'; set 'stream: true' to send them as a stream, or use a single 'response'", res.Path)
 	}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -2,6 +2,8 @@ package config
 
 import "testing"
 
+func boolPtr(b bool) *bool { return &b }
+
 func TestValidateUpstreams(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -288,7 +290,7 @@ func TestValidateStreaming(t *testing.T) {
 		{
 			name: "rest: multiple responses with stream is valid",
 			cfg: Config{Plugin: "rest", Resources: []Resource{{BaseResource: BaseResource{
-				Stream: true, Responses: streamSeq()}}}},
+				Stream: boolPtr(true), Responses: streamSeq()}}}},
 		},
 		{
 			name: "rest: multiple responses without stream is an error",
@@ -299,12 +301,12 @@ func TestValidateStreaming(t *testing.T) {
 		{
 			name: "rest: single response with stream is valid",
 			cfg: Config{Plugin: "rest", Resources: []Resource{{BaseResource: BaseResource{
-				Stream: true, Response: &Response{Content: "a", Headers: sseHeaders}}}}},
+				Stream: boolPtr(true), Response: &Response{Content: "a", Headers: sseHeaders}}}}},
 		},
 		{
 			name: "rest: schedule with stream is valid",
 			cfg: Config{Plugin: "rest", Resources: []Resource{{BaseResource: BaseResource{
-				Stream: true, Response: &Response{Content: "open"}, Schedule: pushSchedule()}}}},
+				Stream: boolPtr(true), Response: &Response{Content: "open"}, Schedule: pushSchedule()}}}},
 		},
 		{
 			name: "rest: schedule without stream is an error",
@@ -315,18 +317,31 @@ func TestValidateStreaming(t *testing.T) {
 		{
 			name: "rest: stream with nothing to stream is an error",
 			cfg: Config{Plugin: "rest", Resources: []Resource{{BaseResource: BaseResource{
-				Stream: true}}}},
+				Stream: boolPtr(true)}}}},
 			wantErr: true,
+		},
+		{
+			name: "websocket: explicit stream:false is an error (always streams)",
+			cfg: Config{Plugin: "websocket", Resources: []Resource{{BaseResource: BaseResource{
+				RequestMatcher: RequestMatcher{Path: "/ws", On: "open"},
+				Stream:         boolPtr(false), Response: &Response{Content: "hi"}}}}},
+			wantErr: true,
+		},
+		{
+			name: "websocket: redundant stream:true is accepted",
+			cfg: Config{Plugin: "websocket", Resources: []Resource{{BaseResource: BaseResource{
+				RequestMatcher: RequestMatcher{Path: "/ws", On: "open"},
+				Stream:         boolPtr(true), Response: &Response{Content: "hi"}}}}},
 		},
 		{
 			name: "openapi: streaming inherits from the rest pipeline",
 			cfg: Config{Plugin: "openapi", Resources: []Resource{{BaseResource: BaseResource{
-				Stream: true, Responses: streamSeq()}}}},
+				Stream: boolPtr(true), Responses: streamSeq()}}}},
 		},
 		{
 			name: "soap: responses are not supported",
 			cfg: Config{Plugin: "soap", Resources: []Resource{{BaseResource: BaseResource{
-				Stream: true, Responses: streamSeq()}}}},
+				Stream: boolPtr(true), Responses: streamSeq()}}}},
 			wantErr: true,
 		},
 	}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -270,3 +270,76 @@ func TestValidateScheduleLimit(t *testing.T) {
 		t.Fatal("expected error for negative limit, got nil")
 	}
 }
+
+func TestValidateStreaming(t *testing.T) {
+	sseHeaders := map[string]string{"Content-Type": "text/event-stream"}
+	streamSeq := func() []Response {
+		return []Response{{Content: "a", Headers: sseHeaders}, {Content: "b"}}
+	}
+	pushSchedule := func() []Schedule {
+		return []Schedule{{Every: "1s", Response: &Response{Content: "tick"}}}
+	}
+
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr bool
+	}{
+		{
+			name: "rest: multiple responses with stream is valid",
+			cfg: Config{Plugin: "rest", Resources: []Resource{{BaseResource: BaseResource{
+				Stream: true, Responses: streamSeq()}}}},
+		},
+		{
+			name: "rest: multiple responses without stream is an error",
+			cfg: Config{Plugin: "rest", Resources: []Resource{{BaseResource: BaseResource{
+				Responses: streamSeq()}}}},
+			wantErr: true,
+		},
+		{
+			name: "rest: single response with stream is valid",
+			cfg: Config{Plugin: "rest", Resources: []Resource{{BaseResource: BaseResource{
+				Stream: true, Response: &Response{Content: "a", Headers: sseHeaders}}}}},
+		},
+		{
+			name: "rest: schedule with stream is valid",
+			cfg: Config{Plugin: "rest", Resources: []Resource{{BaseResource: BaseResource{
+				Stream: true, Response: &Response{Content: "open"}, Schedule: pushSchedule()}}}},
+		},
+		{
+			name: "rest: schedule without stream is an error",
+			cfg: Config{Plugin: "rest", Resources: []Resource{{BaseResource: BaseResource{
+				Schedule: pushSchedule()}}}},
+			wantErr: true,
+		},
+		{
+			name: "rest: stream with nothing to stream is an error",
+			cfg: Config{Plugin: "rest", Resources: []Resource{{BaseResource: BaseResource{
+				Stream: true}}}},
+			wantErr: true,
+		},
+		{
+			name: "openapi: streaming inherits from the rest pipeline",
+			cfg: Config{Plugin: "openapi", Resources: []Resource{{BaseResource: BaseResource{
+				Stream: true, Responses: streamSeq()}}}},
+		},
+		{
+			name: "soap: responses are not supported",
+			cfg: Config{Plugin: "soap", Resources: []Resource{{BaseResource: BaseResource{
+				Stream: true, Responses: streamSeq()}}}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Validate(&tt.cfg)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/internal/emit/emit.go
+++ b/internal/emit/emit.go
@@ -1,0 +1,74 @@
+// Package emit holds the transport-agnostic machinery for sending one or more
+// processed responses to a client over a long-lived exchange — a websocket
+// connection or a streamed HTTP response. The websocket plugin and the HTTP
+// streaming path share these primitives so that "process a response block,
+// then send it" (and "fire a schedule that emits responses") lives in one
+// place rather than being duplicated per protocol.
+package emit
+
+import (
+	"github.com/imposter-project/imposter-go/internal/config"
+	"github.com/imposter-project/imposter-go/internal/exchange"
+	"github.com/imposter-project/imposter-go/internal/response"
+)
+
+// Sink delivers a processed response body to a client transport (a websocket
+// text frame, an HTTP response stream, ...). It decouples the shared response
+// handling from the protocol that carries the bytes.
+type Sink interface {
+	// Emit sends the body currently held in the response state. It returns
+	// false when the sink can accept no more — typically because the client
+	// has gone away — signalling callers to stop emitting further responses.
+	Emit(rs *exchange.ResponseState) bool
+}
+
+// DiscardSink accepts and drops every body. It is used where responses must be
+// processed for their side effects (captures, steps, templating) but must not
+// be sent — for example a websocket 'close' event, after which no frame can be
+// delivered.
+type DiscardSink struct{}
+
+// Emit implements Sink by discarding the body.
+func (DiscardSink) Emit(*exchange.ResponseState) bool { return true }
+
+// EmitOne sends the body currently in the response state via the sink, if any,
+// then clears the per-response fields so the next response starts clean. It
+// reports whether the sink accepted the body (false means stop). A response
+// with an empty body is a no-op that always reports true.
+func EmitOne(rs *exchange.ResponseState, sink Sink) bool {
+	accepted := true
+	if len(rs.Body) > 0 {
+		accepted = sink.Emit(rs)
+	}
+	rs.Body = nil
+	rs.File = ""
+	return accepted
+}
+
+// EmitResponses processes each response block through respProc and emits the
+// result via the sink, in order, stopping early if the sink stops accepting
+// (client gone). Per-block delays configured on each response are honoured by
+// respProc before the block is emitted, which paces the stream. It returns the
+// number of non-empty bodies emitted.
+func EmitResponses(
+	exch *exchange.Exchange,
+	reqMatcher *config.RequestMatcher,
+	resps []config.Response,
+	respProc response.Processor,
+	sink Sink,
+) int {
+	rs := exch.ResponseState
+	var emitted int
+	for i := range resps {
+		respProc(exch, reqMatcher, &resps[i])
+		hadBody := len(rs.Body) > 0
+		accepted := EmitOne(rs, sink)
+		if hadBody && accepted {
+			emitted++
+		}
+		if !accepted {
+			break
+		}
+	}
+	return emitted
+}

--- a/internal/emit/emit.go
+++ b/internal/emit/emit.go
@@ -1,9 +1,8 @@
 // Package emit holds the transport-agnostic machinery for sending one or more
 // processed responses to a client over a long-lived exchange — a websocket
-// connection or a streamed HTTP response. The websocket plugin and the HTTP
-// streaming path share these primitives so that "process a response block,
-// then send it" (and "fire a schedule that emits responses") lives in one
-// place rather than being duplicated per protocol.
+// connection or a streamed HTTP response. Each transport provides a Sink that
+// delivers a single processed body; on top of that the package processes a list
+// of responses (EmitResponses) and drives scheduled emission (ScheduleHost).
 package emit
 
 import (

--- a/internal/emit/emit_test.go
+++ b/internal/emit/emit_test.go
@@ -1,0 +1,240 @@
+package emit
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/imposter-project/imposter-go/internal/config"
+	"github.com/imposter-project/imposter-go/internal/exchange"
+	"github.com/imposter-project/imposter-go/internal/response"
+	"github.com/imposter-project/imposter-go/internal/store"
+)
+
+// captureSink records every emitted body. When stopAfter is positive it stops
+// accepting (returns false) once that many bodies have been recorded.
+type captureSink struct {
+	bodies    []string
+	stopAfter int
+}
+
+func (s *captureSink) Emit(rs *exchange.ResponseState) bool {
+	if s.stopAfter > 0 && len(s.bodies) >= s.stopAfter {
+		return false
+	}
+	s.bodies = append(s.bodies, string(rs.Body))
+	return true
+}
+
+func newExchange(t *testing.T, method, path string) (*exchange.Exchange, *store.Store) {
+	t.Helper()
+	req := httptest.NewRequest(method, path, nil)
+	rs := response.NewResponseState()
+	st := store.NewRequestStore()
+	return exchange.NewExchange(req, nil, st, rs), st
+}
+
+func contentProcessor() response.Processor {
+	return response.NewProcessor(&config.ImposterConfig{}, "")
+}
+
+func TestEmitResponses_EmitsEachBodyInOrder(t *testing.T) {
+	exch, _ := newExchange(t, http.MethodPost, "/chat")
+	resps := []config.Response{
+		{Content: "one"},
+		{Content: "two"},
+		{Content: "three"},
+	}
+	sink := &captureSink{}
+
+	emitted := EmitResponses(exch, &config.RequestMatcher{}, resps, contentProcessor(), sink)
+
+	if emitted != 3 {
+		t.Fatalf("expected 3 emitted, got %d", emitted)
+	}
+	want := []string{"one", "two", "three"}
+	for i, w := range want {
+		if sink.bodies[i] != w {
+			t.Errorf("body[%d] = %q, want %q", i, sink.bodies[i], w)
+		}
+	}
+	if len(exch.ResponseState.Body) != 0 {
+		t.Errorf("expected response body cleared after emit, got %q", exch.ResponseState.Body)
+	}
+}
+
+func TestEmitResponses_StopsWhenSinkRejects(t *testing.T) {
+	exch, _ := newExchange(t, http.MethodPost, "/chat")
+	resps := []config.Response{{Content: "a"}, {Content: "b"}, {Content: "c"}}
+	sink := &captureSink{stopAfter: 1}
+
+	emitted := EmitResponses(exch, &config.RequestMatcher{}, resps, contentProcessor(), sink)
+
+	if emitted != 1 {
+		t.Fatalf("expected 1 emitted before sink rejected, got %d", emitted)
+	}
+	if len(sink.bodies) != 1 || sink.bodies[0] != "a" {
+		t.Errorf("expected only first body emitted, got %v", sink.bodies)
+	}
+}
+
+func TestEmitOne_EmptyBodyIsNoOp(t *testing.T) {
+	rs := response.NewResponseState()
+	sink := &captureSink{}
+	if !EmitOne(rs, sink) {
+		t.Error("EmitOne with empty body should report accepted")
+	}
+	if len(sink.bodies) != 0 {
+		t.Errorf("expected no bodies emitted for empty response, got %v", sink.bodies)
+	}
+}
+
+func TestDiscardSink_DropsBodies(t *testing.T) {
+	rs := response.NewResponseState()
+	rs.Body = []byte("dropped")
+	if !EmitOne(rs, DiscardSink{}) {
+		t.Error("DiscardSink should always accept")
+	}
+	if len(rs.Body) != 0 {
+		t.Errorf("expected body cleared after EmitOne, got %q", rs.Body)
+	}
+}
+
+func TestStreamHTTP_WritesChunksAndFlushes(t *testing.T) {
+	exch, _ := newExchange(t, http.MethodPost, "/chat")
+	rec := httptest.NewRecorder()
+	exch.ResponseWriter = rec
+
+	resource := &config.BaseResource{
+		Stream: true,
+		Responses: []config.Response{
+			{Content: "chunk1", Headers: map[string]string{"Content-Type": "text/event-stream"}},
+			{Content: "chunk2"},
+		},
+	}
+
+	StreamHTTP(exch, resource, contentProcessor(), &config.ImposterConfig{}, "")
+
+	if !exch.ResponseState.Streamed {
+		t.Error("expected response state marked Streamed")
+	}
+	if got := rec.Body.String(); got != "chunk1chunk2" {
+		t.Errorf("streamed body = %q, want %q", got, "chunk1chunk2")
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want text/event-stream", ct)
+	}
+	if !rec.Flushed {
+		t.Error("expected the writer to have been flushed")
+	}
+}
+
+// nonFlushingWriter is an http.ResponseWriter that does not implement
+// http.Flusher, exercising the buffered fallback path.
+type nonFlushingWriter struct {
+	header http.Header
+	status int
+	body   []byte
+}
+
+func (w *nonFlushingWriter) Header() http.Header    { return w.header }
+func (w *nonFlushingWriter) WriteHeader(status int) { w.status = status }
+func (w *nonFlushingWriter) Write(b []byte) (int, error) {
+	w.body = append(w.body, b...)
+	return len(b), nil
+}
+
+func TestStreamHTTP_BufferedFallbackWhenNotFlushable(t *testing.T) {
+	exch, _ := newExchange(t, http.MethodPost, "/chat")
+	exch.ResponseWriter = &nonFlushingWriter{header: http.Header{}}
+
+	resource := &config.BaseResource{
+		Stream: true,
+		Responses: []config.Response{
+			{Content: "chunk1"},
+			{Content: "chunk2"},
+		},
+	}
+
+	StreamHTTP(exch, resource, contentProcessor(), &config.ImposterConfig{}, "")
+
+	// The fallback concatenates into a single buffered body written the normal
+	// way, so it must NOT mark the response Streamed.
+	if exch.ResponseState.Streamed {
+		t.Error("buffered fallback should not mark the response Streamed")
+	}
+	if got := string(exch.ResponseState.Body); got != "chunk1chunk2" {
+		t.Errorf("buffered body = %q, want %q", got, "chunk1chunk2")
+	}
+}
+
+func TestScheduleHost_FiresUntilLimit(t *testing.T) {
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	host := &ScheduleHost{
+		Ctx:            ctx,
+		ImposterConfig: &config.ImposterConfig{},
+		RespProc:       contentProcessor(),
+		Sink:           sink,
+		Label:          "test",
+		Schedules: []config.Schedule{
+			{
+				Every:    "10ms",
+				Limit:    3,
+				Response: &config.Response{Content: "tick"},
+			},
+		},
+		NewExchange: func() *exchange.Exchange {
+			req := httptest.NewRequest(http.MethodGet, "/events", nil)
+			return exchange.NewExchange(req, nil, store.NewRequestStore(), response.NewResponseState())
+		},
+	}
+
+	var wg sync.WaitGroup
+	host.Start(&wg)
+	wg.Wait()
+
+	if len(sink.bodies) != 3 {
+		t.Fatalf("expected 3 scheduled emissions (limit), got %d: %v", len(sink.bodies), sink.bodies)
+	}
+	for i, b := range sink.bodies {
+		if b != "tick" {
+			t.Errorf("emission[%d] = %q, want %q", i, b, "tick")
+		}
+	}
+}
+
+func TestScheduleHost_StopsOnContextCancel(t *testing.T) {
+	sink := &captureSink{}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	host := &ScheduleHost{
+		Ctx:            ctx,
+		ImposterConfig: &config.ImposterConfig{},
+		RespProc:       contentProcessor(),
+		Sink:           sink,
+		Label:          "test",
+		Schedules: []config.Schedule{
+			{Every: "10ms", Response: &config.Response{Content: "tick"}}, // unlimited
+		},
+		NewExchange: func() *exchange.Exchange {
+			req := httptest.NewRequest(http.MethodGet, "/events", nil)
+			return exchange.NewExchange(req, nil, store.NewRequestStore(), response.NewResponseState())
+		},
+	}
+
+	var wg sync.WaitGroup
+	host.Start(&wg)
+	time.Sleep(35 * time.Millisecond)
+	cancel()
+	wg.Wait() // must return promptly once the context is cancelled
+
+	if len(sink.bodies) == 0 {
+		t.Error("expected at least one emission before cancel")
+	}
+}

--- a/internal/emit/emit_test.go
+++ b/internal/emit/emit_test.go
@@ -109,7 +109,6 @@ func TestStreamHTTP_WritesChunksAndFlushes(t *testing.T) {
 	exch.ResponseWriter = rec
 
 	resource := &config.BaseResource{
-		Stream: true,
 		Responses: []config.Response{
 			{Content: "chunk1", Headers: map[string]string{"Content-Type": "text/event-stream"}},
 			{Content: "chunk2"},
@@ -152,7 +151,6 @@ func TestStreamHTTP_BufferedFallbackWhenNotFlushable(t *testing.T) {
 	exch.ResponseWriter = &nonFlushingWriter{header: http.Header{}}
 
 	resource := &config.BaseResource{
-		Stream: true,
 		Responses: []config.Response{
 			{Content: "chunk1"},
 			{Content: "chunk2"},

--- a/internal/emit/httpstream.go
+++ b/internal/emit/httpstream.go
@@ -1,0 +1,135 @@
+package emit
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/imposter-project/imposter-go/internal/config"
+	"github.com/imposter-project/imposter-go/internal/exchange"
+	"github.com/imposter-project/imposter-go/internal/response"
+	"github.com/imposter-project/imposter-go/pkg/logger"
+)
+
+// httpSink writes processed response bodies to an HTTP client incrementally,
+// flushing after each so the client receives them as they are produced. The
+// status line and headers are written once, from the first emitted response.
+type httpSink struct {
+	w           http.ResponseWriter
+	flusher     http.Flusher
+	req         *http.Request
+	wroteHeader bool
+}
+
+// Emit writes and flushes one response body, returning false once the client
+// has disconnected or a write fails so the caller stops.
+func (s *httpSink) Emit(rs *exchange.ResponseState) bool {
+	if s.req.Context().Err() != nil {
+		// Client has gone away.
+		return false
+	}
+	if !s.wroteHeader {
+		for key, value := range rs.Headers {
+			s.w.Header().Set(key, value)
+		}
+		status := rs.StatusCode
+		if status == 0 {
+			status = http.StatusOK
+		}
+		s.w.WriteHeader(status)
+		s.wroteHeader = true
+	}
+	if len(rs.Body) > 0 {
+		if _, err := s.w.Write(rs.Body); err != nil {
+			logger.Debugf("stream write failed - path:%s, error:%v", s.req.URL.Path, err)
+			return false
+		}
+	}
+	s.flusher.Flush()
+	return true
+}
+
+// StreamHTTP writes a matched resource's responses to the HTTP client
+// incrementally, flushing each, then runs any request-scoped schedules until
+// they reach their limit or the client disconnects. It marks the response
+// state Streamed so the buffered writer does not write the body again.
+//
+// When the underlying writer cannot flush (e.g. the AWS Lambda adapter), it
+// falls back to buffering every response into a single body written the normal
+// way, and skips schedules (which need a live, flushable connection).
+func StreamHTTP(
+	exch *exchange.Exchange,
+	resource *config.BaseResource,
+	respProc response.Processor,
+	imposterConfig *config.ImposterConfig,
+	configDir string,
+) {
+	rs := exch.ResponseState
+	reqMatcher := &resource.RequestMatcher
+	resps := resource.EffectiveResponses()
+
+	flusher, ok := exch.ResponseWriter.(http.Flusher)
+	if !ok {
+		streamBuffered(exch, resource, resps, respProc)
+		return
+	}
+
+	req := exch.Request.Request
+	logger.Infof("streaming response - method:%s, path:%s, chunks:%d, schedules:%d",
+		req.Method, req.URL.Path, len(resps), len(resource.Schedule))
+
+	sink := &httpSink{w: exch.ResponseWriter, flusher: flusher, req: req}
+
+	// Emit the fixed sequence first (e.g. an SSE body ending in [DONE]).
+	EmitResponses(exch, reqMatcher, resps, respProc, sink)
+
+	// Then run any request-scoped schedules (open-ended server push). This
+	// blocks until every schedule hits its limit or the client disconnects,
+	// keeping the HTTP response open in the meantime.
+	if len(resource.Schedule) > 0 {
+		var wg sync.WaitGroup
+		host := &ScheduleHost{
+			Ctx:            req.Context(),
+			Schedules:      resource.Schedule,
+			Label:          "request " + req.URL.Path,
+			ImposterConfig: imposterConfig,
+			ConfigDir:      configDir,
+			RespProc:       respProc,
+			Sink:           sink,
+			NewExchange: func() *exchange.Exchange {
+				return exchange.NewExchange(req, nil, exch.RequestStore, response.NewResponseState())
+			},
+		}
+		host.Start(&wg)
+		wg.Wait()
+	}
+
+	rs.Streamed = true
+	rs.HandledWithResource(resource)
+}
+
+// streamBuffered is the non-flushing fallback: it concatenates every response
+// body into one, written via the normal buffered path, and warns that
+// schedules are unsupported without a flushable writer.
+func streamBuffered(
+	exch *exchange.Exchange,
+	resource *config.BaseResource,
+	resps []config.Response,
+	respProc response.Processor,
+) {
+	rs := exch.ResponseState
+	req := exch.Request.Request
+	logger.Debugf("streaming unavailable (writer is not flushable); buffering %d response(s) - path:%s", len(resps), req.URL.Path)
+
+	var buf []byte
+	for i := range resps {
+		respProc(exch, &resource.RequestMatcher, &resps[i])
+		buf = append(buf, rs.Body...)
+		rs.Body = nil
+		rs.File = ""
+	}
+	rs.Body = buf
+
+	if len(resource.Schedule) > 0 {
+		logger.Warnf("resource (path %q) declares a schedule but the connection cannot stream; schedule skipped", resource.Path)
+	}
+}

--- a/internal/emit/schedule.go
+++ b/internal/emit/schedule.go
@@ -18,8 +18,7 @@ import (
 // its trigger until the context is cancelled or its firing limit is reached.
 // Each firing runs the entry's steps, then emits its responses via the sink.
 //
-// This is the generalisation of the websocket plugin's connection-scoped
-// schedules: only NewExchange and Sink differ between protocols.
+// A caller binds it to a transport by supplying NewExchange and a Sink.
 type ScheduleHost struct {
 	// Ctx bounds every schedule's lifetime; cancelling it stops all of them
 	// (e.g. the websocket connection closed, or the HTTP client disconnected).

--- a/internal/emit/schedule.go
+++ b/internal/emit/schedule.go
@@ -1,0 +1,94 @@
+package emit
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/imposter-project/imposter-go/internal/config"
+	"github.com/imposter-project/imposter-go/internal/exchange"
+	"github.com/imposter-project/imposter-go/internal/response"
+	"github.com/imposter-project/imposter-go/internal/scheduler"
+	"github.com/imposter-project/imposter-go/internal/steps"
+	"github.com/imposter-project/imposter-go/pkg/logger"
+)
+
+// ScheduleHost runs a set of scoped schedules — connection-scoped (a websocket
+// connection) or request-scoped (a streamed HTTP response) — firing each on
+// its trigger until the context is cancelled or its firing limit is reached.
+// Each firing runs the entry's steps, then emits its responses via the sink.
+//
+// This is the generalisation of the websocket plugin's connection-scoped
+// schedules: only NewExchange and Sink differ between protocols.
+type ScheduleHost struct {
+	// Ctx bounds every schedule's lifetime; cancelling it stops all of them
+	// (e.g. the websocket connection closed, or the HTTP client disconnected).
+	Ctx context.Context
+
+	// Schedules are the entries to run.
+	Schedules []config.Schedule
+
+	// Label identifies this host in log messages, e.g. "connection /ws" or
+	// "request /events".
+	Label string
+
+	ImposterConfig *config.ImposterConfig
+	ConfigDir      string
+	RespProc       response.Processor
+	Sink           Sink
+
+	// NewExchange builds a fresh exchange for a single firing. Each firing gets
+	// its own response state so concurrent or successive firings do not clash;
+	// the protocol supplies the request and request-scoped store that captures
+	// and templates dereference.
+	NewExchange func() *exchange.Exchange
+}
+
+// Start launches one goroutine per schedule, registering each on wg. It returns
+// immediately; callers that must not outlive the schedules (e.g. an HTTP
+// handler holding the response open) should wg.Wait().
+func (h *ScheduleHost) Start(wg *sync.WaitGroup) {
+	if len(h.Schedules) == 0 {
+		return
+	}
+	logger.Debugf("starting %d scoped schedule(s) - %s", len(h.Schedules), h.Label)
+
+	for i := range h.Schedules {
+		entry := &h.Schedules[i]
+		name := fmt.Sprintf("%s (%s)", scheduler.ScheduleName(entry, i), h.Label)
+		next, err := scheduler.TriggerFunc(entry)
+		if err != nil {
+			// Validation runs at startup, so this should be unreachable.
+			logger.Errorf("invalid trigger for schedule %s: %v", name, err)
+			continue
+		}
+
+		limit := scheduler.EffectiveLimit(entry)
+		logger.Debugf("registered schedule %s (%s)", name, scheduler.DescribeTrigger(entry, limit))
+
+		wg.Add(1)
+		go func(entry *config.Schedule, name string, next scheduler.NextFireFunc, limit int) {
+			defer wg.Done()
+			scheduler.RunSchedule(h.Ctx, name, next, limit, func() {
+				h.fire(entry, name)
+			})
+		}(entry, name, next, limit)
+	}
+}
+
+// fire executes one firing: run the entry's steps, then emit each of its
+// responses via the sink.
+func (h *ScheduleHost) fire(entry *config.Schedule, name string) {
+	exch := h.NewExchange()
+	reqMatcher := &config.RequestMatcher{}
+
+	if len(entry.Steps) > 0 {
+		if err := steps.RunSteps(entry.Steps, exch, h.ImposterConfig, h.ConfigDir, exch.ResponseState, reqMatcher); err != nil {
+			logger.Errorf("schedule %s: failed to execute steps: %v", name, err)
+			return
+		}
+	}
+
+	emitted := EmitResponses(exch, reqMatcher, entry.EffectiveResponses(), h.RespProc, h.Sink)
+	logger.Debugf("schedule %s: run completed (%d step(s), %d response(s) emitted)", name, len(entry.Steps), emitted)
+}

--- a/internal/exchange/state.go
+++ b/internal/exchange/state.go
@@ -15,6 +15,7 @@ type ResponseState struct {
 	Stopped          bool                 // indicates if the response has been stopped (e.g., connection closed)
 	Handled          bool                 // indicates if a handler has handled the request
 	Hijacked         bool                 // indicates a plugin has taken over the underlying connection (e.g. websocket upgrade)
+	Streamed         bool                 // indicates the body was already written incrementally to the client (streaming); the buffered write is skipped
 	Resource         *config.BaseResource // the resource that handled the request
 	Delay            config.Delay         // delay configuration for the response
 	Fail             string               // failure type for the response
@@ -30,8 +31,9 @@ func (rs *ResponseState) HandledWithResource(resource *config.BaseResource) {
 
 // WriteToResponseWriter writes the final state to the http.ResponseWriter
 func (rs *ResponseState) WriteToResponseWriter(w http.ResponseWriter) {
-	if rs.Hijacked {
-		// The connection has been taken over (e.g. websocket upgrade); nothing
+	if rs.Hijacked || rs.Streamed {
+		// The connection has been taken over (e.g. websocket upgrade) or the
+		// body was already streamed to the client incrementally; nothing more
 		// may be written, but cleanup functions still run.
 		for _, cleanup := range rs.CleanupFunctions {
 			if cleanup != nil {

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -205,7 +205,7 @@ func RunPipeline(
 
 	// Process the response(s) if configured. A singular 'response' block is
 	// equivalent to a 'responses' list with one element.
-	if best.Resource.Stream && exch.ResponseWriter != nil {
+	if best.Resource.StreamEnabled() && exch.ResponseWriter != nil {
 		// Stream the responses to the client incrementally (HTTP SSE/chunked),
 		// including any request-scoped schedules, instead of buffering a single
 		// body. Guarded on ResponseWriter so it only applies to live HTTP

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -6,6 +6,7 @@ import (
 	"github.com/imposter-project/imposter-go/internal/capture"
 	"github.com/imposter-project/imposter-go/internal/common"
 	"github.com/imposter-project/imposter-go/internal/config"
+	"github.com/imposter-project/imposter-go/internal/emit"
 	"github.com/imposter-project/imposter-go/internal/exchange"
 	"github.com/imposter-project/imposter-go/internal/matcher"
 	"github.com/imposter-project/imposter-go/internal/passthrough"
@@ -204,9 +205,17 @@ func RunPipeline(
 
 	// Process the response(s) if configured. A singular 'response' block is
 	// equivalent to a 'responses' list with one element.
-	resps := best.Resource.EffectiveResponses()
-	for i := range resps {
-		processResp(exch, &best.Resource.RequestMatcher, &resps[i], respProc)
+	if best.Resource.Stream && exch.ResponseWriter != nil {
+		// Stream the responses to the client incrementally (HTTP SSE/chunked),
+		// including any request-scoped schedules, instead of buffering a single
+		// body. Guarded on ResponseWriter so it only applies to live HTTP
+		// requests (websocket uses its own frame sink with a nil writer).
+		emit.StreamHTTP(exch, &best.Resource.BaseResource, respProc, imposterConfig, cfg.ConfigDir)
+	} else {
+		resps := best.Resource.EffectiveResponses()
+		for i := range resps {
+			processResp(exch, &best.Resource.RequestMatcher, &resps[i], respProc)
+		}
 	}
 
 	// If we matched a resource, ensure the request is marked as handled

--- a/plugin/websocket/connection.go
+++ b/plugin/websocket/connection.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/imposter-project/imposter-go/internal/config"
+	"github.com/imposter-project/imposter-go/internal/emit"
 	"github.com/imposter-project/imposter-go/internal/exchange"
 	"github.com/imposter-project/imposter-go/internal/matcher"
 	"github.com/imposter-project/imposter-go/internal/pipeline"
@@ -197,23 +198,32 @@ func (c *wsConn) runEventPipeline(event string, body []byte) *exchange.ResponseS
 	return responseState
 }
 
+// frameSink emits processed response bodies as websocket text frames. It is
+// the websocket implementation of emit.Sink.
+type frameSink struct{ c *wsConn }
+
+// Emit enqueues the processed body as a text frame. It always reports true:
+// send() itself gives up if the connection has closed, and the read loop is
+// what actually tears the connection down.
+func (s frameSink) Emit(rs *exchange.ResponseState) bool {
+	s.c.send(rs.Body)
+	return true
+}
+
 // processAndSend runs standard response processing (delay, file/content
 // resolution, templating) and enqueues the result as a text frame, reporting
-// whether a frame was sent.
+// whether a frame was sent. Close events pass sendFrame=false, so the response
+// is processed (for its captures and steps) but discarded rather than sent.
 func (c *wsConn) processAndSend(exch *exchange.Exchange, reqMatcher *config.RequestMatcher,
 	resp *config.Response, sendFrame bool,
 ) bool {
 	c.handler.respProc(exch, reqMatcher, resp)
 
-	rs := exch.ResponseState
-	sent := false
-	if sendFrame && len(rs.Body) > 0 {
-		c.send(rs.Body)
-		sent = true
+	hadBody := len(exch.ResponseState.Body) > 0
+	var sink emit.Sink = frameSink{c}
+	if !sendFrame {
+		sink = emit.DiscardSink{}
 	}
-	// Reset per-response fields so subsequent responses in a 'responses'
-	// list start clean.
-	rs.Body = nil
-	rs.File = ""
-	return sent
+	emit.EmitOne(exch.ResponseState, sink)
+	return sendFrame && hadBody
 }

--- a/plugin/websocket/schedule.go
+++ b/plugin/websocket/schedule.go
@@ -8,8 +8,8 @@ import (
 )
 
 // startSchedules launches connection-scoped schedules declared on the matched
-// 'on: open' resource, via the shared emit.ScheduleHost. They stop when the
-// connection closes (c.ctx is cancelled) or when their firing limit is reached.
+// 'on: open' resource, via emit.ScheduleHost. They stop when the connection
+// closes (c.ctx is cancelled) or when their firing limit is reached.
 //
 // Each firing gets a fresh response state but reuses the connection-scoped
 // request store, so values captured by one firing are visible to later ones.

--- a/plugin/websocket/schedule.go
+++ b/plugin/websocket/schedule.go
@@ -1,69 +1,30 @@
 package websocket
 
 import (
-	"fmt"
-
 	"github.com/imposter-project/imposter-go/internal/config"
+	"github.com/imposter-project/imposter-go/internal/emit"
 	"github.com/imposter-project/imposter-go/internal/exchange"
 	"github.com/imposter-project/imposter-go/internal/response"
-	"github.com/imposter-project/imposter-go/internal/scheduler"
-	"github.com/imposter-project/imposter-go/internal/steps"
-	"github.com/imposter-project/imposter-go/pkg/logger"
 )
 
-// startSchedules launches connection-scoped schedules declared on the
-// matched 'on: open' resource. They stop when the connection closes or when
-// their firing limit is reached.
+// startSchedules launches connection-scoped schedules declared on the matched
+// 'on: open' resource, via the shared emit.ScheduleHost. They stop when the
+// connection closes (c.ctx is cancelled) or when their firing limit is reached.
+//
+// Each firing gets a fresh response state but reuses the connection-scoped
+// request store, so values captured by one firing are visible to later ones.
 func (c *wsConn) startSchedules(resource *config.BaseResource) {
-	if len(resource.Schedule) == 0 {
-		return
+	host := &emit.ScheduleHost{
+		Ctx:            c.ctx,
+		Schedules:      resource.Schedule,
+		Label:          "connection " + c.upgrade.URL.Path,
+		ImposterConfig: c.handler.imposterConfig,
+		ConfigDir:      c.handler.config.ConfigDir,
+		RespProc:       c.handler.respProc,
+		Sink:           frameSink{c},
+		NewExchange: func() *exchange.Exchange {
+			return exchange.NewExchange(c.upgrade, nil, c.requestStore, response.NewResponseState())
+		},
 	}
-	logger.Debugf("starting %d connection-scoped schedule(s) - path:%s", len(resource.Schedule), c.upgrade.URL.Path)
-
-	for i := range resource.Schedule {
-		entry := &resource.Schedule[i]
-		name := fmt.Sprintf("%s (connection %s)", scheduler.ScheduleName(entry, i), c.upgrade.URL.Path)
-		next, err := scheduler.TriggerFunc(entry)
-		if err != nil {
-			// Validation runs at startup, so this should be unreachable.
-			logger.Errorf("invalid trigger for schedule %s: %v", name, err)
-			continue
-		}
-
-		limit := scheduler.EffectiveLimit(entry)
-		logger.Debugf("registered schedule %s (%s)", name, scheduler.DescribeTrigger(entry, limit))
-
-		c.wg.Add(1)
-		go func(entry *config.Schedule, name string, next scheduler.NextFireFunc, limit int) {
-			defer c.wg.Done()
-			scheduler.RunSchedule(c.ctx, name, next, limit, func() {
-				c.fireSchedule(entry, name)
-			})
-		}(entry, name, next, limit)
-	}
-}
-
-// fireSchedule executes one firing of a connection-scoped schedule: any steps
-// run first, then each response block is processed and sent as a text frame.
-func (c *wsConn) fireSchedule(entry *config.Schedule, name string) {
-	h := c.handler
-	responseState := response.NewResponseState()
-	exch := exchange.NewExchange(c.upgrade, nil, c.requestStore, responseState)
-	reqMatcher := &config.RequestMatcher{}
-
-	if len(entry.Steps) > 0 {
-		if err := steps.RunSteps(entry.Steps, exch, h.imposterConfig, h.config.ConfigDir, responseState, reqMatcher); err != nil {
-			logger.Errorf("schedule %s: failed to execute steps: %v", name, err)
-			return
-		}
-	}
-
-	var frames int
-	resps := entry.EffectiveResponses()
-	for i := range resps {
-		if c.processAndSend(exch, reqMatcher, &resps[i], true) {
-			frames++
-		}
-	}
-	logger.Debugf("schedule %s: run completed (%d step(s), %d frame(s) sent)", name, len(entry.Steps), frames)
+	host.Start(&c.wg)
 }


### PR DESCRIPTION
## Summary

Adds incremental HTTP streaming to the `rest` and `openapi` plugins via `stream: true`, and generalises the websocket plugin's multiple-response and scheduled-frame machinery into a protocol-agnostic core (`internal/emit`) that HTTP and websocket now share.

Two capabilities on a streamed resource:

- **Fixed sequence** — a `responses` list is written and flushed one chunk at a time, paced by each block's `delay`. Ideal for an OpenAI-style token stream ending in `[DONE]`.
- **Open-ended push** — a `schedule` on a streamed resource pushes further responses over the open connection until its `limit` is reached or the client disconnects (SSE keepalive, progress, live data).

```yaml
plugin: rest
resources:
  - path: /v1/chat/completions
    method: POST
    stream: true
    responses:
      - content: "data: {...}\n\n"
        headers: { Content-Type: text/event-stream }
        delay: { exact: 50 }
      - content: "data: [DONE]\n\n"
```

## The generalisation (DRY)

New core package `internal/emit`:

- `Sink` — abstracts "send one processed response body" (a websocket text frame, or an HTTP flushed chunk).
- `EmitResponses` — the shared process-then-emit loop (per-block delay/file/content/template).
- `ScheduleHost` — runs connection- or request-scoped schedules through the existing `internal/scheduler`, emitting via a `Sink`.

The **websocket plugin is refactored onto these** (a `frameSink` + `ScheduleHost`), deleting its bespoke send/schedule code. **OpenAPI inherits streaming for free** because it already serves responses through the REST pipeline. The top-level engine-lifetime `scheduler` is unchanged (no client sink; avoids an import cycle).

## Behaviour & safety

- Chunked (`Transfer-Encoding: chunked`); status/headers taken from the first chunk. SSE framing is authored in the content, so the same mechanism serves NDJSON or any chunked format.
- **Client disconnect** stops request-scoped schedules promptly (via `r.Context()`).
- **Non-flushable connections** (AWS Lambda adapter): chunks are concatenated into one buffered response and schedules are skipped with a warning.
- **Validation**: multiple `responses` or a `schedule` on an HTTP resource require `stream: true`; `stream: true` with nothing to stream is rejected; schedule-entry checks are shared between websocket and HTTP.

## Tests & docs

- Unit tests for `internal/emit` (emit loop, buffered fallback, schedule limit + context-cancel), streaming validation tests. Full suite: **30 packages pass**; `go test -race` clean on the concurrency-sensitive packages.
- New `examples/rest/sse-streaming` example and `docs/streaming.md`.

Verified end-to-end on the native engine: 50 ms SSE pacing to `[DONE]`; scheduled push honouring `limit` and stopping on client disconnect; and OpenAPI streaming through the shared pipeline.