### PR TITLE
fix: respect server base path in swagger UI and WSDL viewer URLs

### DIFF
--- a/external/plugins/oidc-server/auth.go
+++ b/external/plugins/oidc-server/auth.go
@@ -167,10 +167,7 @@ func (o *OIDCServer) renderLoginForm(sessionID, clientID string, errorMsg ...str
 		errorMessage = errorMsg[0]
 	}
 
-	serverBase := ""
-	if parsed, err := url.Parse(o.serverURL); err == nil {
-		serverBase = strings.TrimRight(parsed.Path, "/")
-	}
+	serverBase := shared.ServerBasePath(o.serverURL)
 
 	data := struct {
 		SessionID  string

--- a/external/plugins/swaggerui/ui.go
+++ b/external/plugins/swaggerui/ui.go
@@ -33,7 +33,7 @@ func serveStaticContent(path string) shared.HandlerResponse {
 	path = strings.TrimPrefix(path, specPrefixPath)
 	if len(path) == 0 {
 		return shared.HandlerResponse{StatusCode: 302, Headers: map[string]string{
-			"Location": specPrefixPath + "/",
+			"Location": shared.ServerBasePath(config.Server.URL) + specPrefixPath + "/",
 		}}
 	}
 
@@ -68,8 +68,18 @@ func serveStaticContent(path string) shared.HandlerResponse {
 
 // generateInitialiser generates the index page response using the embedded template.
 func generateInitialiser() error {
-	// serialise the specConfigs to JSON
-	jsonData, err := json.Marshal(specConfigs)
+	// Prepend the server base path to each spec URL so Swagger UI fetches them
+	// through any reverse-proxy base path. The stored specConfigs are left
+	// untouched, as their un-prefixed URLs are used for internal route matching.
+	basePath := shared.ServerBasePath(config.Server.URL)
+	browserConfigs := make([]SpecConfig, len(specConfigs))
+	for i, specConfig := range specConfigs {
+		specConfig.URL = basePath + specConfig.URL
+		browserConfigs[i] = specConfig
+	}
+
+	// serialise the browser-facing specConfigs to JSON
+	jsonData, err := json.Marshal(browserConfigs)
 	if err != nil {
 		return fmt.Errorf("failed to marshal spec config JSON: %w", err)
 	}

--- a/external/plugins/swaggerui/ui_test.go
+++ b/external/plugins/swaggerui/ui_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/imposter-project/imposter-go/external/shared"
 )
 
 func TestServeStaticContent_EmptyPath(t *testing.T) {
@@ -42,5 +45,78 @@ func TestServeStaticContent_EmptyPathWithCustomPrefix(t *testing.T) {
 	expectedLocation := "/custom/"
 	if result.Headers["Location"] != expectedLocation {
 		t.Errorf("Expected Location header '%s', got '%s'", expectedLocation, result.Headers["Location"])
+	}
+}
+
+func TestServeStaticContent_EmptyPathWithServerBasePath(t *testing.T) {
+	// When IMPOSTER_SERVER_URL includes a base path (e.g. behind a reverse
+	// proxy), the trailing-slash redirect must include that base path so the
+	// browser resolves it against the proxy rather than the origin root.
+	originalSpecPrefix := specPrefixPath
+	originalConfig := config
+	defer func() { specPrefixPath = originalSpecPrefix; config = originalConfig }()
+
+	specPrefixPath = "/_spec"
+	config = shared.ExternalConfig{Server: shared.ServerConfig{URL: "http://localhost:8080/myapp"}}
+
+	result := serveStaticContent("/_spec")
+
+	if result.StatusCode != 302 {
+		t.Errorf("Expected status code 302, got %d", result.StatusCode)
+	}
+
+	expectedLocation := "/myapp/_spec/"
+	if result.Headers["Location"] != expectedLocation {
+		t.Errorf("Expected Location header '%s', got '%s'", expectedLocation, result.Headers["Location"])
+	}
+}
+
+func TestGenerateInitialiser_SpecUrlServerBasePath(t *testing.T) {
+	originalSpecConfigs := specConfigs
+	originalConfig := config
+	originalResp := initialiserResp
+	defer func() {
+		specConfigs = originalSpecConfigs
+		config = originalConfig
+		initialiserResp = originalResp
+	}()
+
+	specConfigs = []SpecConfig{{Name: "petstore.yaml", URL: "/_spec/openapi/petstore.yaml"}}
+
+	tests := []struct {
+		name        string
+		serverURL   string
+		expectedURL string
+	}{
+		{
+			name:        "no base path",
+			serverURL:   "http://localhost:8080",
+			expectedURL: `"url":"/_spec/openapi/petstore.yaml"`,
+		},
+		{
+			name:        "with base path",
+			serverURL:   "http://localhost:8080/myapp",
+			expectedURL: `"url":"/myapp/_spec/openapi/petstore.yaml"`,
+		},
+		{
+			name:        "base path with trailing slash",
+			serverURL:   "http://localhost:8080/myapp/",
+			expectedURL: `"url":"/myapp/_spec/openapi/petstore.yaml"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config = shared.ExternalConfig{Server: shared.ServerConfig{URL: tt.serverURL}}
+
+			if err := generateInitialiser(); err != nil {
+				t.Fatalf("generateInitialiser returned error: %v", err)
+			}
+
+			body := string(initialiserResp.Body)
+			if !strings.Contains(body, tt.expectedURL) {
+				t.Errorf("expected initialiser to contain %s, got body: %s", tt.expectedURL, body)
+			}
+		})
 	}
 }

--- a/external/plugins/wsdlweb/ui.go
+++ b/external/plugins/wsdlweb/ui.go
@@ -34,7 +34,7 @@ func serveStaticContent(path string) shared.HandlerResponse {
 	path = strings.TrimPrefix(path, wsdlPrefixPath)
 	if len(path) == 0 {
 		return shared.HandlerResponse{StatusCode: 302, Headers: map[string]string{
-			"Location": wsdlPrefixPath + "/",
+			"Location": shared.ServerBasePath(config.Server.URL) + wsdlPrefixPath + "/",
 		}}
 	}
 

--- a/external/plugins/wsdlweb/ui_test.go
+++ b/external/plugins/wsdlweb/ui_test.go
@@ -2,7 +2,32 @@ package main
 
 import (
 	"testing"
+
+	"github.com/imposter-project/imposter-go/external/shared"
 )
+
+func TestServeStaticContent_EmptyPathWithServerBasePath(t *testing.T) {
+	// When IMPOSTER_SERVER_URL includes a base path (e.g. behind a reverse
+	// proxy), the trailing-slash redirect must include that base path so the
+	// browser resolves it against the proxy rather than the origin root.
+	originalPrefix := wsdlPrefixPath
+	originalConfig := config
+	defer func() { wsdlPrefixPath = originalPrefix; config = originalConfig }()
+
+	wsdlPrefixPath = "/_wsdl"
+	config = shared.ExternalConfig{Server: shared.ServerConfig{URL: "http://localhost:8080/myapp"}}
+
+	result := serveStaticContent("/_wsdl")
+
+	if result.StatusCode != 302 {
+		t.Errorf("Expected status code 302, got %d", result.StatusCode)
+	}
+
+	expectedLocation := "/myapp/_wsdl/"
+	if result.Headers["Location"] != expectedLocation {
+		t.Errorf("Expected Location header '%s', got '%s'", expectedLocation, result.Headers["Location"])
+	}
+}
 
 func TestServeStaticContent_EmptyPath(t *testing.T) {
 	originalPrefix := wsdlPrefixPath

--- a/external/shared/serverurl.go
+++ b/external/shared/serverurl.go
@@ -1,0 +1,21 @@
+package shared
+
+import (
+	"net/url"
+	"strings"
+)
+
+// ServerBasePath returns the path component of the given server URL, with any
+// trailing slash removed. Plugins prepend it to browser-facing, root-relative
+// URLs so they resolve correctly when Imposter is hosted behind a reverse proxy
+// under a base path (e.g. /myapp). Internal route matching is unaffected, as the
+// proxy strips the base path before requests reach Imposter.
+//
+// It returns an empty string when the server URL has no path component or cannot
+// be parsed.
+func ServerBasePath(serverURL string) string {
+	if parsed, err := url.Parse(serverURL); err == nil {
+		return strings.TrimRight(parsed.Path, "/")
+	}
+	return ""
+}

--- a/external/shared/serverurl_test.go
+++ b/external/shared/serverurl_test.go
@@ -1,0 +1,26 @@
+package shared
+
+import "testing"
+
+func TestServerBasePath(t *testing.T) {
+	tests := []struct {
+		name      string
+		serverURL string
+		expected  string
+	}{
+		{name: "no path", serverURL: "http://localhost:8080", expected: ""},
+		{name: "root path only", serverURL: "http://localhost:8080/", expected: ""},
+		{name: "single segment", serverURL: "http://localhost:8080/myapp", expected: "/myapp"},
+		{name: "single segment with trailing slash", serverURL: "http://localhost:8080/myapp/", expected: "/myapp"},
+		{name: "multiple segments", serverURL: "https://example.com/foo/bar", expected: "/foo/bar"},
+		{name: "empty string", serverURL: "", expected: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ServerBasePath(tt.serverURL); got != tt.expected {
+				t.Errorf("ServerBasePath(%q) = %q, want %q", tt.serverURL, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Follows up on #101 (OIDC login form base path). That PR fixed one instance of a browser-facing, root-relative URL ignoring the path component of `IMPOSTER_SERVER_URL`. This addresses the remaining instances found by auditing the rest of the codebase, and extracts the shared logic so it isn't duplicated across plugins.

When Imposter is hosted behind a reverse proxy under a base path (e.g. `https://example.com/myapp`, with `IMPOSTER_SERVER_URL` set accordingly), any root-relative URL handed to the browser is resolved against the origin, dropping the base path and bypassing the proxy.

## Key changes

- **Shared helper**: added `shared.ServerBasePath(serverURL)` to the lightweight `external/shared` package (returns the path component with any trailing slash trimmed, empty when absent or unparseable). The three plugins now reuse it instead of each carrying its own copy — #101's inline version in oidc-server is replaced with a call to it too.
- **swaggerui**: the spec list handed to `SwaggerUIBundle({urls: ...})` used root-relative URLs (e.g. `/_spec/openapi/foo.yaml`) with no base path, so the browser fetched them from the origin root and the specs failed to load behind a base-path proxy. `generateInitialiser` now prepends the server base path to the browser-facing URLs. The stored `specConfigs` are left untouched, since their un-prefixed URLs are used for internal route matching (the proxy strips the base path before the request reaches Imposter).
- **swaggerui / wsdlweb**: the trailing-slash redirect (`Location: /_spec/` and `/_wsdl/`) was also root-relative and dropped the base path. Both now include it.

The base path is taken from the path component of `IMPOSTER_SERVER_URL` only, keeping the URLs same-origin — consistent with #101. When `IMPOSTER_SERVER_URL` has no path component, behaviour is unchanged.

### Not changed

- OIDC redirect `Location` headers target the client-supplied, validated absolute `redirect_uri` / `post_logout_redirect_uri` and are correctly left as-is.
- The OpenAPI discovery document, issuer, and endpoint URLs are already built from `serverURL + pathPrefix` (fully absolute, base path included).
- wsdlweb's spec URL list already respects the base path via `baseUrlOverride`.