### PR TITLE
ci: populate release body from changelog extract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,12 +68,56 @@ jobs:
       with:
         go-version: '1.25'
 
+    # Pulls the entries for the version being released out of CHANGELOG.md, so
+    # the release body matches the curated changelog rather than raw git log.
+    - name: Extract changelog entries
+      uses: release-tools/since@v0.20.0
+      with:
+        changelog-file: CHANGELOG.md
+        output-file: .changelog-extract.md
+
+    - name: Compose release notes
+      id: release_notes
+      env:
+        TAG: ${{ github.ref_name }}
+      run: |
+        set -euo pipefail
+
+        version="${TAG#v}"
+        latest_entry="$(grep -m 1 '^## ' CHANGELOG.md)"
+        case "$latest_entry" in
+          *"[${version}]"*) ;;
+          *)
+            echo "::error::Most recent CHANGELOG.md entry is '${latest_entry}', expected one for ${version}"
+            exit 1
+            ;;
+        esac
+
+        previous_tag="$(git describe --tags --abbrev=0 --match 'v*' "${TAG}^" 2>/dev/null || true)"
+
+        notes="${RUNNER_TEMP}/release-notes.md"
+        {
+          echo "## imposter-go ${TAG} ($(date -u '+%Y-%m-%d'))"
+          echo
+          echo "For installation instructions, please visit https://github.com/imposter-project/imposter-go#installation"
+          echo "For user documentation, please visit https://docs.imposter.sh"
+          echo
+          cat .changelog-extract.md
+          if [ -n "$previous_tag" ]; then
+            echo
+            echo "**Full Changelog**: https://github.com/imposter-project/imposter-go/compare/${previous_tag}...${TAG}"
+          fi
+        } > "$notes"
+
+        echo "path=${notes}" >> "$GITHUB_OUTPUT"
+        cat "$notes"
+
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v7
       with:
         distribution: goreleaser
         version: latest
-        args: release --clean
+        args: release --clean --release-notes=${{ steps.release_notes.outputs.path }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ coverage.html
 
 # Testing
 /.playwright-mcp/
+
+# Release notes extracted from CHANGELOG.md during CI
+/.changelog-extract.md

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,18 +47,14 @@ checksum:
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 
+# The release body is supplied by CI via `--release-notes`, built from the
+# CHANGELOG.md entries for the tag (see the release job in .github/workflows/ci.yml).
+# GoReleaser skips its own changelog, header and footer when release notes are
+# passed in, so that content lives alongside the extract step in the workflow.
 release:
   github:
     owner: imposter-project
     name: imposter-go
   draft: false
   prerelease: auto
-  mode: replace
-  header: |
-    ## imposter-go {{ .Tag }} ({{ .Date }})
-    
-    For installation instructions, please visit https://github.com/imposter-project/imposter-go#installation
-    For user documentation, please visit https://docs.imposter.sh
-  
-  footer: |
-    **Full Changelog**: https://github.com/imposter-project/imposter-go/compare/{{ .PreviousTag }}...{{ .Tag }} 
+  mode: replace 

--- a/docs/release.md
+++ b/docs/release.md
@@ -10,12 +10,18 @@ To create a new release:
 
 2. The GitHub Actions workflow will automatically:
     - Build binaries for all supported platforms (Linux, macOS, Windows)
-    - Generate a changelog from commit messages
+    - Extract the entries for the tagged version from `CHANGELOG.md`
     - Create a GitHub release
     - Upload the built artifacts
 
 The release notes will include:
 - Version and release date
-- Automatically generated changelog (excluding docs, test, ci, and chore commits)
 - Installation instructions
+- The `CHANGELOG.md` entries for the tagged version
 - Link to the full changelog comparing with the previous tag
+
+The entries are extracted by the [since](https://github.com/release-tools/since)
+action and passed to GoReleaser via `--release-notes`, so the release body
+matches the changelog exactly. The release job fails if the most recent entry in
+`CHANGELOG.md` is not for the tag being released — run `since project release`
+(or update the changelog by hand) before tagging.


### PR DESCRIPTION
GitHub release bodies are now built from the curated `CHANGELOG.md` entries for the tagged version, instead of GoReleaser's raw git log.

## Summary
- Add a `release-tools/since@v0.20.0` step to the release job, extracting the `CHANGELOG.md` entries for the version being released
- Compose the release body from those entries plus the existing header and footer, and pass it to GoReleaser via `--release-notes`
- Fail the release job early if the most recent changelog entry is not for the tag being released
- Drop the now-unused `release.header` and `release.footer` from `.goreleaser.yml`, and ignore the extract file so it cannot dirty the tree
- Update the release process docs to describe where the release body comes from

## Implementation details
GoReleaser's changelog pipe returns early when release notes are supplied, so neither its generated changelog nor the configured header and footer are rendered. Leaving them in `.goreleaser.yml` would be dead config, so their content moves into the compose step in the workflow, preserved verbatim; the previous tag for the compare link comes from `git describe` and the footer is omitted if there isn't one.

GoReleaser's dirty check is `git status --porcelain`, which includes untracked files, so the extract is written to a gitignored path and the composed notes to `$RUNNER_TEMP` — keeping both out of the working tree and out of the release archives.

The version guard matters because the extract defaults to the most recent changelog section: without it, a tag pushed ahead of the changelog would publish a body describing the previous release, with nothing to signal the mismatch.