### PR TITLE
fix: add CA certificates to scratch images for outbound TLS

### DIFF
--- a/distro/all/Dockerfile
+++ b/distro/all/Dockerfile
@@ -30,6 +30,8 @@ RUN for p in $(cd ./external/plugins && ls); do \
 RUN mkdir -p /tmp /opt/imposter/config
 
 FROM scratch
+# Root CAs for outbound TLS, e.g. upstream passthrough, remote steps and remote spec loading
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /imposter-go /imposter-go
 COPY --from=build --chmod=0600 /tmp /tmp/
 COPY --from=build --chmod=0755 /opt/imposter/config /opt/imposter/config/

--- a/distro/core/Dockerfile
+++ b/distro/core/Dockerfile
@@ -15,6 +15,8 @@ RUN go build -tags lambda.norpc -ldflags "-s -w -X github.com/imposter-project/i
 RUN mkdir -p /tmp /opt/imposter/config /opt/imposter/plugins
 
 FROM scratch
+# Root CAs for outbound TLS, e.g. upstream passthrough, remote steps and remote spec loading
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /imposter-go /imposter-go
 COPY --from=build --chmod=0600 /tmp /tmp/
 COPY --from=build --chmod=0755 /opt/imposter/config /opt/imposter/config/


### PR DESCRIPTION
Adds the root CA bundle to the `core` and `all` Docker images so outbound HTTPS calls work.

## Summary

- Copy the Debian CA bundle from the build stage into the final `scratch` image in both `distro/core/Dockerfile` and `distro/all/Dockerfile`.
- Fixes outbound TLS for upstream passthrough (`internal/passthrough/passthrough.go`), remote steps (`internal/steps/remote/remote.go`) and remote OpenAPI spec loading (`plugin/openapi/specloader.go`), all of which previously failed against any `https://` URL.

## Implementation details

Both images build `FROM scratch`, which ships no trust store. Every outbound call uses the default `http.Transport` and so falls back to an empty root pool, failing with `x509: certificate signed by unknown authority`. The caller only sees a generic 502 — the TLS cause appears solely in the container logs, which makes this awkward to diagnose.

The bundle is copied to `/etc/ssl/certs/ca-certificates.crt`, the first path `crypto/x509` probes on Linux, so no code change or environment variable is required. It comes out of the existing `golang:1.26` build stage, so nothing extra is installed.

Cost is 224 KB uncompressed and 130 KB gzipped, against a 42.3 MB / 12.0 MB binary — roughly 0.5% and 1.1% respectively.

Verified by running the `examples/rest/passthrough` config against images built with and without the change: the HTTPS-backed route returns 502 before and 200 with real upstream data after, while the locally mocked route returns 200 in both cases.

Note that the certificates are pinned at build time, so picking up root CA distrust events depends on a rebuild.