### PR TITLE
fix: remove header when withHeader receives null or undefined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ coverage.html
 
 # Release notes extracted from CHANGELOG.md during CI
 /.changelog-extract.md
+/opencode/plans

--- a/internal/exchange/exchange_test.go
+++ b/internal/exchange/exchange_test.go
@@ -68,6 +68,25 @@ func TestResponseState_SetHeader(t *testing.T) {
 	assert.False(t, rs.IsHeaderExplicit("X-Not-Set"))
 }
 
+func TestResponseState_RemoveHeader(t *testing.T) {
+	rs := &ResponseState{}
+	rs.SetHeader("X-Custom", "value")
+
+	rs.RemoveHeader("X-Custom")
+
+	assert.NotContains(t, rs.Headers, "X-Custom")
+	assert.False(t, rs.IsHeaderExplicit("X-Custom"))
+}
+
+func TestResponseState_RemoveHeader_NoOp(t *testing.T) {
+	rs := &ResponseState{Headers: map[string]string{}}
+
+	rs.RemoveHeader("X-NonExistent")
+
+	assert.Empty(t, rs.Headers)
+	assert.False(t, rs.IsHeaderExplicit("X-NonExistent"))
+}
+
 func TestResponseState_ClearExplicitFlags(t *testing.T) {
 	rs := &ResponseState{}
 	rs.SetStatusCode(http.StatusTeapot)

--- a/internal/exchange/state.go
+++ b/internal/exchange/state.go
@@ -80,6 +80,16 @@ func (rs *ResponseState) IsHeaderExplicit(name string) bool {
 	return rs.explicitHeaders[http.CanonicalHeaderKey(name)]
 }
 
+// RemoveHeader removes a header and clears its explicit flag so that a
+// configured response header can apply as a fallback.
+func (rs *ResponseState) RemoveHeader(name string) {
+	delete(rs.Headers, name)
+	canonical := http.CanonicalHeaderKey(name)
+	if rs.explicitHeaders != nil {
+		delete(rs.explicitHeaders, canonical)
+	}
+}
+
 // ClearExplicitFlags forgets that the status code, body and headers were
 // explicitly set, allowing a subsequent configured response to be applied
 // unconditionally. This is used where the configured response must win

--- a/internal/steps/script/respond.go
+++ b/internal/steps/script/respond.go
@@ -29,8 +29,15 @@ func (rb *ResponseBuilder) withFile(filePath string) goja.Value {
 	return rb.obj
 }
 
-func (rb *ResponseBuilder) withHeader(name, value string) goja.Value {
-	rb.state.SetHeader(name, value)
+func (rb *ResponseBuilder) withHeader(call goja.FunctionCall) goja.Value {
+	name := call.Argument(0).ToString().String()
+	value := call.Argument(1)
+
+	if goja.IsNull(value) || goja.IsUndefined(value) {
+		rb.state.RemoveHeader(name)
+	} else {
+		rb.state.SetHeader(name, value.ToString().String())
+	}
 	return rb.obj
 }
 

--- a/internal/steps/script/script_test.go
+++ b/internal/steps/script/script_test.go
@@ -387,6 +387,113 @@ func TestExecuteScriptStep(t *testing.T) {
 			},
 		},
 		{
+			name: "response builder withHeader null removes header",
+			step: config.Step{
+				Type: config.ScriptStepType,
+				Lang: "javascript",
+				Code: `
+					respond()
+						.withHeader("X-A", null)
+				`,
+			},
+			setupExch: func() *exchange.Exchange {
+				req, _ := http.NewRequest("GET", "/test", nil)
+				return &exchange.Exchange{
+					Request: &exchange.RequestContext{
+						Request: req,
+						Body:    []byte{},
+					},
+				}
+			},
+			validate: func(t *testing.T, rs *exchange.ResponseState) {
+				assert.NotContains(t, rs.Headers, "X-A")
+				assert.False(t, rs.IsHeaderExplicit("X-A"))
+			},
+			reqMatcher: &config.RequestMatcher{
+				Path: "/test",
+			},
+		},
+		{
+			name: "response builder withHeader undefined removes header",
+			step: config.Step{
+				Type: config.ScriptStepType,
+				Lang: "javascript",
+				Code: `
+					respond()
+						.withHeader("X-A", undefined)
+				`,
+			},
+			setupExch: func() *exchange.Exchange {
+				req, _ := http.NewRequest("GET", "/test", nil)
+				return &exchange.Exchange{
+					Request: &exchange.RequestContext{
+						Request: req,
+						Body:    []byte{},
+					},
+				}
+			},
+			validate: func(t *testing.T, rs *exchange.ResponseState) {
+				assert.NotContains(t, rs.Headers, "X-A")
+			},
+			reqMatcher: &config.RequestMatcher{
+				Path: "/test",
+			},
+		},
+		{
+			name: "response builder withHeader set then remove",
+			step: config.Step{
+				Type: config.ScriptStepType,
+				Lang: "javascript",
+				Code: `
+					respond()
+						.withHeader("X-A", "v")
+						.withHeader("X-A", null)
+				`,
+			},
+			setupExch: func() *exchange.Exchange {
+				req, _ := http.NewRequest("GET", "/test", nil)
+				return &exchange.Exchange{
+					Request: &exchange.RequestContext{
+						Request: req,
+						Body:    []byte{},
+					},
+				}
+			},
+			validate: func(t *testing.T, rs *exchange.ResponseState) {
+				assert.NotContains(t, rs.Headers, "X-A")
+				assert.False(t, rs.IsHeaderExplicit("X-A"))
+			},
+			reqMatcher: &config.RequestMatcher{
+				Path: "/test",
+			},
+		},
+		{
+			name: "response builder withHeader remove non-existent is no-op",
+			step: config.Step{
+				Type: config.ScriptStepType,
+				Lang: "javascript",
+				Code: `
+					respond()
+						.withHeader("X-Missing", null)
+				`,
+			},
+			setupExch: func() *exchange.Exchange {
+				req, _ := http.NewRequest("GET", "/test", nil)
+				return &exchange.Exchange{
+					Request: &exchange.RequestContext{
+						Request: req,
+						Body:    []byte{},
+					},
+				}
+			},
+			validate: func(t *testing.T, rs *exchange.ResponseState) {
+				assert.Empty(t, rs.Headers)
+			},
+			reqMatcher: &config.RequestMatcher{
+				Path: "/test",
+			},
+		},
+		{
 			name: "response builder with failure - EmptyResponse",
 			step: config.Step{
 				Type: config.ScriptStepType,


### PR DESCRIPTION
## Key changes

- Add `RemoveHeader` method to `ResponseState` to delete a header and clear its explicit flag
- Change `withHeader` to accept `goja.FunctionCall` and inspect the raw JavaScript value
- Call `RemoveHeader` when the value is `null` or `undefined`, matching JVM engine behaviour

## Implementation details

The existing signature `withHeader(name, value string)` coerced `null` to `"` via goja's type conversion. Accepting `goja.FunctionCall` allows inspection of the raw value using `goja.IsNull()` and `goja.IsUndefined()` package functions.

When a header is removed, its explicit flag is also cleared so that a configured response header can apply as a fallback.

Closes #110.